### PR TITLE
do not include withName function if name param is read only

### DIFF
--- a/src/tf_schema.py
+++ b/src/tf_schema.py
@@ -213,6 +213,8 @@ def jsonnet_new_fn(name, attributes_in_new, attributes, has_native_name, **kwarg
   if not has_native_name:
     params.remove("name")
   for param in params:
+    if attributes_in_new[param].is_read_only:
+      continue
     fn_name = jsonnet_with_fn_name(param)
     new_parts.append(f"+ block.{fn_name}({param})")
   new_parts.append(")")

--- a/src/tf_schema.py
+++ b/src/tf_schema.py
@@ -210,11 +210,9 @@ def jsonnet_new_fn(name, attributes_in_new, attributes, has_native_name, **kwarg
     }},
   }}"""
   new_parts = [f"new({params_str}):: (", new_body]
-  if not has_native_name:
+  if not has_native_name or attributes_in_new["name"].is_read_only:
     params.remove("name")
   for param in params:
-    if attributes_in_new[param].is_read_only:
-      continue
     fn_name = jsonnet_with_fn_name(param)
     new_parts.append(f"+ block.{fn_name}({param})")
   new_parts.append(")")


### PR DESCRIPTION
couldn't test because of some errors:
```
$ ./jsonnet-tf --provider okta/okta --provider-version "~> 5.3.0" --terraform-version ">= 1.12.1"
building...
+ docker build --quiet -t jsonnet-tf -f Dockerfile.docker .
+ set +x
done

generating...
+ docker run --mount type=bind,src=./artifacts,dst=/artifacts -t jsonnet-tf --provider okta/okta --provider-version '~> 5.3.0' --terraform-version '>= 1.12.1'
Initializing the backend...
Initializing provider plugins...
- Finding okta/okta versions matching "~> 5.3.0"...
╷
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider okta/okta: could not connect to registry.terraform.io: failed to request discovery
│ document: Get "https://registry.terraform.io/.well-known/terraform.json": EOF
│ 
│ To see which modules are currently depending on okta/okta and what versions are specified, run the following command:
│     terraform providers
╵
╷
│ Error: Inconsistent dependency lock file
│ 
│ The following dependency selections recorded in the lock file are inconsistent with the current configuration:
│   - provider registry.terraform.io/okta/okta: required by this configuration but no version is selected
│ 
│ To make the initial dependency selections that will initialize the dependency lock file, run:
│   terraform init
╵

Traceback (most recent call last):
  File "/app/main.py", line 109, in <module>
    main()
  File "/app/.cache/pypoetry/virtualenvs/jsonnet-tf-py-9TtSrW0h-py3.12/lib/python3.12/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.cache/pypoetry/virtualenvs/jsonnet-tf-py-9TtSrW0h-py3.12/lib/python3.12/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/app/.cache/pypoetry/virtualenvs/jsonnet-tf-py-9TtSrW0h-py3.12/lib/python3.12/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.cache/pypoetry/virtualenvs/jsonnet-tf-py-9TtSrW0h-py3.12/lib/python3.12/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/main.py", line 66, in main
    providers_schema = get_providers_schema(provider, provider_source, provider_version, terraform_version, force)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/main.py", line 103, in get_providers_schema
    return tf_schema.ProvidersSchema.from_json(schemas_file.read())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.cache/pypoetry/virtualenvs/jsonnet-tf-py-9TtSrW0h-py3.12/lib/python3.12/site-packages/dataclass_wizard/serial_json.py", line 33, in from_json
    o = decoder(string, **decoder_kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/decoder.py", line 338, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/decoder.py", line 356, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```