### PR TITLE
[fix]: remove unnecessary conversions and inject some new lines

### DIFF
--- a/src/tf_schema.py
+++ b/src/tf_schema.py
@@ -342,7 +342,7 @@ class Attribute(JSONWizard):
                   }}
                 )""")
 
-        return ",\n".join(fns)
+        return ",\n\n".join(fns)
 
 
 @dataclass
@@ -563,7 +563,7 @@ class Block(JSONWizard):
         if nested_type_code:
             body_parts.append(nested_type_code)
 
-        body = ",\n".join(body_parts)
+        body = ",\n\n".join(body_parts)
 
         # Return appropriately formatted code
         if is_library_top_level:

--- a/src/tf_schema.py
+++ b/src/tf_schema.py
@@ -86,7 +86,7 @@ def jsonnet_with_fn_mixin_name(name: str) -> str:
 
 def auto_conversion(
     type_spec: Optional[Union[str, List[str]]], from_localvar: str, to_localvar: str
-) -> str:
+) -> str | None:
     """Generate Jsonnet code to convert values based on type.
 
     Args:
@@ -105,7 +105,7 @@ def auto_conversion(
     if type_spec in ("list", "set"):
         return f"local {to_localvar} = if std.isArray({from_localvar}) then {from_localvar} else [{from_localvar}];"
 
-    return f"local {to_localvar} = {from_localvar};"
+    return None
 
 
 def assertion(
@@ -157,7 +157,9 @@ def description(attribute: Any, fn_name: str) -> Optional[str]:
         Jsonnet code for the description comment or None if no description
     """
     if attribute.description is not None:
-        _description = attribute.description.replace("\n", " ").replace('"', "'").replace("\\", "")
+        _description = (
+            attribute.description.replace("\n", " ").replace('"', "'").replace("\\", "")
+        )
         return f'"#{fn_name}":: "{_description}"'
     return None
 
@@ -177,7 +179,7 @@ def jsonnet_with_terraform_name() -> str:
   }}"""
 
 
-def jsonnet_with_fn(name: str, conversion: str) -> str:
+def jsonnet_with_fn(name: str, conversion: str | None = None) -> str:
     """Generate a standard 'with' function for a field.
 
     Args:
@@ -193,14 +195,13 @@ def jsonnet_with_fn(name: str, conversion: str) -> str:
         name = f"'{name}'"
 
     return f"""{fn_name}(value):: (
-    {conversion}
-    {{
-      {name}: value,
+    {f"{conversion}\n" if conversion else ""}{{
+      {name}: {"converted" if conversion else "value"},
     }}
   )"""
 
 
-def jsonnet_with_fn_mixin(name: str, conversion: str) -> str:
+def jsonnet_with_fn_mixin(name: str, conversion: str | None = None) -> str:
     """Generate a 'with' mixin function for a field.
 
     Args:
@@ -216,9 +217,8 @@ def jsonnet_with_fn_mixin(name: str, conversion: str) -> str:
         name = f"'{name}'"
 
     return f"""{fn_name}(value):: (
-    {conversion}
-    {{
-      {name}+: converted,
+    {f"{conversion}\n" if conversion else ""}{{
+      {name}+:  {"converted" if conversion else "value"},
     }}
   )"""
 
@@ -303,9 +303,16 @@ class Attribute(JSONWizard):
         _conversion = auto_conversion(
             self.type, from_localvar="value", to_localvar="converted"
         )
-        _assertion = assertion(self.type, name, "converted")
+        field_value_localvar = "value" if _conversion is None else "converted"
+        _assertion = assertion(self.type, name, field_value_localvar)
         fn_name = jsonnet_with_fn_name(name)
         _description = description(self, fn_name)
+        fn_prelude = "\n" + (f"{_description},\n" if _description else "")
+        fn_body_prelude = (
+            f"{_assertion}\n"
+            if _conversion is None
+            else f"{_conversion}\n{_assertion}\n"
+        )
 
         # Handle reserved keywords
         if name in RESERVED:
@@ -314,14 +321,10 @@ class Attribute(JSONWizard):
             field = name
 
         fns = []
-        if _description is not None:
-            fns.append(_description)
-
-        fns.append(f"""{fn_name}(value):: (
-      {_conversion}
-      {_assertion}
+        fns.append(f"""{fn_prelude}{fn_name}(value):: (
+      {fn_body_prelude}
       {{
-        {field}: converted,
+        {field}: {field_value_localvar},
       }}
     )""")
 
@@ -330,14 +333,12 @@ class Attribute(JSONWizard):
             if self.type[0] in ("list", "set"):
                 fn_name = jsonnet_with_fn_mixin_name(name)
                 _description = description(self, fn_name)
-                if _description is not None:
-                    fns.append(_description)
+                fn_prelude = f"{_description},\n" if _description else ""
 
-                fns.append(f"""{fn_name}(value):: (
-                  {_conversion}
-                  {_assertion}
+                fns.append(f"""{fn_prelude}{fn_name}(value):: (
+                  {fn_body_prelude}
                   {{
-                    {field}+: converted,
+                    {field}+: {field_value_localvar},
                   }}
                 )""")
 

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,52 +13,58 @@
       },
     }
   ),
+
   "#withActiveOnly":: "Search only ACTIVE applications.",
   withActiveOnly(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"active_only" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"active_only" expected to be of type "bool"';
+
     {
-      active_only: converted,
+      active_only: value,
     }
   ),
+
   "#withId":: "Id of application to retrieve, conflicts with label and label_prefix.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLabel":: "The label of the app to retrieve, conflicts with \t\t\t\tlabel_prefix and id. Label uses the ?q=<label> query parameter exposed by \t\t\t\tOkta's List Apps API. The API will search both name and label using that \t\t\t\tquery. Therefore similarly named and labeled apps may be returned in the query \t\t\t\tand have the unintended result of associating the wrong app with this data \t\t\t\tsource. See: \t\t\t\thttps://developer.okta.com/docs/reference/api/apps/#list-applications",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withLabelPrefix":: "Label prefix of the app to retrieve, conflicts with label and id. This will tell the \t\t\t\tprovider to do a starts with query as opposed to an equals query.",
   withLabelPrefix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label_prefix" expected to be of type "string"';
+    assert std.isString(value) : '"label_prefix" expected to be of type "string"';
+
     {
-      label_prefix: converted,
+      label_prefix: value,
     }
   ),
+
   "#withSkipGroups":: "Ignore groups sync. This is a temporary solution until 'groups' field is supported in all the app-like resources",
   withSkipGroups(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"skip_groups" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"skip_groups" expected to be of type "bool"';
+
     {
-      skip_groups: converted,
+      skip_groups: value,
     }
   ),
+
   "#withSkipUsers":: "Ignore users sync. This is a temporary solution until 'users' field is supported in all the app-like resources",
   withSkipUsers(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"skip_users" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"skip_users" expected to be of type "bool"';
+
     {
-      skip_users: converted,
+      skip_users: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app_group_assignments.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app_group_assignments.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, id):: (
     {
       jsonnetTfMetadata:: {
@@ -13,12 +14,13 @@
     }
     + block.withId(id)
   ),
+
   "#withId":: "ID of the Okta App being queried for groups",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app_metadata_saml.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app_metadata_saml.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, appId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,27 +14,30 @@
     }
     + block.withAppId(appId)
   ),
+
   "#withAppId":: "The application ID.",
   withAppId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_id" expected to be of type "string"';
+    assert std.isString(value) : '"app_id" expected to be of type "string"';
+
     {
-      app_id: converted,
+      app_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withKeyId":: "Certificate Key ID.",
   withKeyId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"key_id" expected to be of type "string"';
+    assert std.isString(value) : '"key_id" expected to be of type "string"';
+
     {
-      key_id: converted,
+      key_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app_oauth.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app_oauth.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,52 +13,58 @@
       },
     }
   ),
+
   "#withActiveOnly":: "Search only ACTIVE applications.",
   withActiveOnly(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"active_only" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"active_only" expected to be of type "bool"';
+
     {
-      active_only: converted,
+      active_only: value,
     }
   ),
+
   "#withId":: "Id of application to retrieve, conflicts with label and label_prefix.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLabel":: "The label of the app to retrieve, conflicts with \t\t\t\tlabel_prefix and id. Label uses the ?q=<label> query parameter exposed by \t\t\t\tOkta's List Apps API. The API will search both name and label using that \t\t\t\tquery. Therefore similarly named and labeled apps may be returned in the query \t\t\t\tand have the unitended result of associating the wrong app with this data \t\t\t\tsource. See: \t\t\t\thttps://developer.okta.com/docs/reference/api/apps/#list-applications",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withLabelPrefix":: "Label prefix of the app to retrieve, conflicts with label and id. This will tell the \t\t\t\tprovider to do a starts with query as opposed to an equals query.",
   withLabelPrefix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label_prefix" expected to be of type "string"';
+    assert std.isString(value) : '"label_prefix" expected to be of type "string"';
+
     {
-      label_prefix: converted,
+      label_prefix: value,
     }
   ),
+
   "#withSkipGroups":: "Ignore groups sync. This is a temporary solution until 'groups' field is supported in all the app-like resources",
   withSkipGroups(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"skip_groups" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"skip_groups" expected to be of type "bool"';
+
     {
-      skip_groups: converted,
+      skip_groups: value,
     }
   ),
+
   "#withSkipUsers":: "Ignore users sync. This is a temporary solution until 'users' field is supported in all the app-like resources",
   withSkipUsers(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"skip_users" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"skip_users" expected to be of type "bool"';
+
     {
-      skip_users: converted,
+      skip_users: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app_saml.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app_saml.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,60 +13,67 @@
       },
     }
   ),
+
   "#withActiveOnly":: "Search only ACTIVE applications.",
   withActiveOnly(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"active_only" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"active_only" expected to be of type "bool"';
+
     {
-      active_only: converted,
+      active_only: value,
     }
   ),
+
   "#withId":: "Id of application to retrieve, conflicts with label and label_prefix.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLabel":: "The label of the app to retrieve, conflicts with label_prefix and id. Label  \t\t\t\tuses the ?q=<label> query parameter exposed by Okta's API. It should be noted that at this time  \t\t\t\tthis searches both name and label. This is used to avoid paginating through all applications.",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withLabelPrefix":: "Label prefix of the app to retrieve, conflicts with label and id. This will tell the \t\t\t\tprovider to do a starts with query as opposed to an equals query.",
   withLabelPrefix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label_prefix" expected to be of type "string"';
+    assert std.isString(value) : '"label_prefix" expected to be of type "string"';
+
     {
-      label_prefix: converted,
+      label_prefix: value,
     }
   ),
+
   "#withRequestCompressed":: "Denotes whether the request is compressed or not.",
   withRequestCompressed(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"request_compressed" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"request_compressed" expected to be of type "bool"';
+
     {
-      request_compressed: converted,
+      request_compressed: value,
     }
   ),
+
   "#withSkipGroups":: "Ignore groups sync. This is a temporary solution until 'groups' field is supported in all the app-like resources",
   withSkipGroups(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"skip_groups" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"skip_groups" expected to be of type "bool"';
+
     {
-      skip_groups: converted,
+      skip_groups: value,
     }
   ),
+
   "#withSkipUsers":: "Ignore users sync. This is a temporary solution until 'users' field is supported in all the app-like resources",
   withSkipUsers(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"skip_users" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"skip_users" expected to be of type "bool"';
+
     {
-      skip_users: converted,
+      skip_users: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app_signon_policy.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app_signon_policy.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, appId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,19 +14,21 @@
     }
     + block.withAppId(appId)
   ),
+
   "#withAppId":: "App ID",
   withAppId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_id" expected to be of type "string"';
+    assert std.isString(value) : '"app_id" expected to be of type "string"';
+
     {
-      app_id: converted,
+      app_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app_user_assignments.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_app_user_assignments.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, id):: (
     {
       jsonnetTfMetadata:: {
@@ -13,12 +14,13 @@
     }
     + block.withId(id)
   ),
+
   "#withId":: "ID of the Okta App being queried for groups",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_apps.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_apps.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,52 +13,58 @@
       },
     }
   ),
+
   "#withActiveOnly":: "Search only active applications.",
   withActiveOnly(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"active_only" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"active_only" expected to be of type "bool"';
+
     {
-      active_only: converted,
+      active_only: value,
     }
   ),
+
   "#withIncludeNonDeleted":: "Specifies whether to include non-active, but not deleted apps in the results.",
   withIncludeNonDeleted(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"include_non_deleted" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"include_non_deleted" expected to be of type "bool"';
+
     {
-      include_non_deleted: converted,
+      include_non_deleted: value,
     }
   ),
+
   "#withLabel":: "Searches for applications whose label or name property matches this value exactly.",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withLabelPrefix":: "Searches for applications whose label or name property begins with this value.",
   withLabelPrefix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label_prefix" expected to be of type "string"';
+    assert std.isString(value) : '"label_prefix" expected to be of type "string"';
+
     {
-      label_prefix: converted,
+      label_prefix: value,
     }
   ),
+
   "#withQ":: "Searches for applications whose name or label properties that starts with this value.",
   withQ(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"q" expected to be of type "string"';
+    assert std.isString(value) : '"q" expected to be of type "string"';
+
     {
-      q: converted,
+      q: value,
     }
   ),
+
   "#withUseOptimization":: "Specifies whether to use query optimization. If you specify `useOptimization=true` in the request query, the response contains a subset of app instance properties.",
   withUseOptimization(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"use_optimization" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"use_optimization" expected to be of type "bool"';
+
     {
-      use_optimization: converted,
+      use_optimization: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_auth_server.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_auth_server.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,19 +14,21 @@
     }
     + block.withName(name)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "The name of the auth server to retrieve.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_auth_server_claim.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_auth_server_claim.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, authServerId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,28 +14,31 @@
     }
     + block.withAuthServerId(authServerId)
   ),
+
   "#withAuthServerId":: "Auth server ID",
   withAuthServerId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"auth_server_id" expected to be of type "string"';
+    assert std.isString(value) : '"auth_server_id" expected to be of type "string"';
+
     {
-      auth_server_id: converted,
+      auth_server_id: value,
     }
   ),
+
   "#withId":: "Name of the claim. Conflicts with `name`.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Name of the claim. Conflicts with `id`.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_auth_server_claims.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_auth_server_claims.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, authServerId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,19 +14,21 @@
     }
     + block.withAuthServerId(authServerId)
   ),
+
   "#withAuthServerId":: "Auth server ID",
   withAuthServerId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"auth_server_id" expected to be of type "string"';
+    assert std.isString(value) : '"auth_server_id" expected to be of type "string"';
+
     {
-      auth_server_id: converted,
+      auth_server_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_auth_server_policy.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_auth_server_policy.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, authServerId, name):: (
     {
       jsonnetTfMetadata:: {
@@ -14,27 +15,30 @@
     + block.withAuthServerId(authServerId)
     + block.withName(name)
   ),
+
   "#withAuthServerId":: "Auth server ID",
   withAuthServerId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"auth_server_id" expected to be of type "string"';
+    assert std.isString(value) : '"auth_server_id" expected to be of type "string"';
+
     {
-      auth_server_id: converted,
+      auth_server_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Name of the policy",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_auth_server_scopes.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_auth_server_scopes.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, authServerId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,19 +14,21 @@
     }
     + block.withAuthServerId(authServerId)
   ),
+
   "#withAuthServerId":: "Auth server ID",
   withAuthServerId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"auth_server_id" expected to be of type "string"';
+    assert std.isString(value) : '"auth_server_id" expected to be of type "string"';
+
     {
-      auth_server_id: converted,
+      auth_server_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_authenticator.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_authenticator.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,28 +13,31 @@
       },
     }
   ),
+
   "#withId":: "ID of the authenticator.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withKey":: "A human-readable string that identifies the authenticator.",
   withKey(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"key" expected to be of type "string"';
+    assert std.isString(value) : '"key" expected to be of type "string"';
+
     {
-      key: converted,
+      key: value,
     }
   ),
+
   "#withName":: "Name of the authenticator.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_behavior.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_behavior.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,20 +13,22 @@
       },
     }
   ),
+
   "#withId":: "Behavior ID.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Behavior name.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_behaviors.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_behaviors.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,19 +13,21 @@
       },
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withQ":: "Searches the name property of behaviors for matching value",
   withQ(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"q" expected to be of type "string"';
+    assert std.isString(value) : '"q" expected to be of type "string"';
+
     {
-      q: converted,
+      q: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_brand.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_brand.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,12 +14,13 @@
     }
     + block.withBrandId(brandId)
   ),
+
   "#withBrandId":: "Brand ID",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_brands.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_brands.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,11 +13,12 @@
       },
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_default_policy.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_default_policy.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, type):: (
     {
       jsonnetTfMetadata:: {
@@ -13,19 +14,21 @@
     }
     + block.withType(type)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withType":: "Policy type: OKTA_SIGN_ON, PASSWORD, MFA_ENROLL, or IDP_DISCOVERY",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_default_signin_page.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_default_signin_page.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,12 +14,13 @@
     }
     + block.withBrandId(brandId)
   ),
+
   "#withBrandId":: "brand id of the preview signin page",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
   withTerraformName(value):: {
@@ -28,26 +30,27 @@
       },
     },
   },
+
   contentSecurityPolicySetting:: {
     local block = self,
+
     new():: (
       {}
     ),
   },
   widgetCustomizations:: {
     local block = self,
+
     new():: (
       {}
     ),
   },
   withContentSecurityPolicySetting(value):: (
-    local converted = value;
     {
       content_security_policy_setting: value,
     }
   ),
   withWidgetCustomizations(value):: (
-    local converted = value;
     {
       widget_customizations: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_device_assurance_policy.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_device_assurance_policy.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,36 +13,40 @@
       },
     }
   ),
+
   "#withId":: "ID of the user type to retrieve, conflicts with `name`.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Name of user type to retrieve, conflicts with `id`.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withSecureHardwarePresent":: "Indicates if the device contains a secure hardware functionality",
   withSecureHardwarePresent(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"secure_hardware_present" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"secure_hardware_present" expected to be of type "bool"';
+
     {
-      secure_hardware_present: converted,
+      secure_hardware_present: value,
     }
   ),
+
   "#withThirdPartySignalProvider":: "Indicates if the device contains a secure hardware functionality",
   withThirdPartySignalProvider(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"third_party_signal_provider" expected to be of type "object"';
+    assert std.isObject(value) : '"third_party_signal_provider" expected to be of type "object"';
+
     {
-      third_party_signal_provider: converted,
+      third_party_signal_provider: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_domain.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_domain.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, domainIdOrName):: (
     {
       jsonnetTfMetadata:: {
@@ -13,12 +14,13 @@
     }
     + block.withDomainIdOrName(domainIdOrName)
   ),
+
   "#withDomainIdOrName":: "Brand ID",
   withDomainIdOrName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"domain_id_or_name" expected to be of type "string"';
+    assert std.isString(value) : '"domain_id_or_name" expected to be of type "string"';
+
     {
-      domain_id_or_name: converted,
+      domain_id_or_name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_email_customization.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_email_customization.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId, customizationId, templateName):: (
     {
       jsonnetTfMetadata:: {
@@ -15,28 +16,31 @@
     + block.withCustomizationId(customizationId)
     + block.withTemplateName(templateName)
   ),
+
   "#withBrandId":: "Brand ID",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   "#withCustomizationId":: "The ID of the customization",
   withCustomizationId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"customization_id" expected to be of type "string"';
+    assert std.isString(value) : '"customization_id" expected to be of type "string"';
+
     {
-      customization_id: converted,
+      customization_id: value,
     }
   ),
+
   "#withTemplateName":: "Template Name",
   withTemplateName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"template_name" expected to be of type "string"';
+    assert std.isString(value) : '"template_name" expected to be of type "string"';
+
     {
-      template_name: converted,
+      template_name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_email_customizations.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_email_customizations.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId, templateName):: (
     {
       jsonnetTfMetadata:: {
@@ -14,27 +15,30 @@
     + block.withBrandId(brandId)
     + block.withTemplateName(templateName)
   ),
+
   "#withBrandId":: "Brand ID",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withTemplateName":: "Template Name",
   withTemplateName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"template_name" expected to be of type "string"';
+    assert std.isString(value) : '"template_name" expected to be of type "string"';
+
     {
-      template_name: converted,
+      template_name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_email_smtp_server.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_email_smtp_server.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, id):: (
     {
       jsonnetTfMetadata:: {
@@ -13,12 +14,13 @@
     }
     + block.withId(id)
   ),
+
   "#withId":: "The ID of the SMTP server.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_email_template.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_email_template.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId, name):: (
     {
       jsonnetTfMetadata:: {
@@ -14,27 +15,30 @@
     + block.withBrandId(brandId)
     + block.withName(name)
   ),
+
   "#withBrandId":: "Brand ID",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "The name of the email template",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_email_templates.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_email_templates.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,19 +14,21 @@
     }
     + block.withBrandId(brandId)
   ),
+
   "#withBrandId":: "Brand ID",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_everyone_group.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_everyone_group.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,19 +13,21 @@
       },
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIncludeUsers":: "Fetch group users, having default off cuts down on API calls.",
   withIncludeUsers(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"include_users" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"include_users" expected to be of type "bool"';
+
     {
-      include_users: converted,
+      include_users: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_features.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_features.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,20 +13,22 @@
       },
     }
   ),
+
   "#withLabel":: "Searches for features whose label or name property matches this value exactly. Case sensitive",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withSubstring":: "Searches for features whose label or name property substring match this value. Case sensitive",
   withSubstring(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"substring" expected to be of type "string"';
+    assert std.isString(value) : '"substring" expected to be of type "string"';
+
     {
-      substring: converted,
+      substring: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_group.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_group.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,44 +13,49 @@
       },
     }
   ),
+
   "#withDelayReadSeconds":: "Force delay of the group read by N seconds. Useful when eventual consistency of group information needs to be allowed for; for instance, when group rules are known to have been applied.",
   withDelayReadSeconds(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"delay_read_seconds" expected to be of type "string"';
+    assert std.isString(value) : '"delay_read_seconds" expected to be of type "string"';
+
     {
-      delay_read_seconds: converted,
+      delay_read_seconds: value,
     }
   ),
+
   "#withId":: "ID of group.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIncludeUsers":: "Fetch group users, having default off cuts down on API calls.",
   withIncludeUsers(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"include_users" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"include_users" expected to be of type "bool"';
+
     {
-      include_users: converted,
+      include_users: value,
     }
   ),
+
   "#withName":: "Name of group.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withType":: "Type of the group. When specified in the terraform resource, will act as a filter when searching for the group",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_group_rule.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_group_rule.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,28 +13,31 @@
       },
     }
   ),
+
   "#withId":: "The ID of the Group Rule.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "The name of the Group Rule.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withStatus":: "Default to `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_groups.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_groups.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,43 +13,48 @@
       },
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLimit":: "The maximum number of groups returned by the Okta API, between 1 and 10000.",
   withLimit(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"limit" expected to be of type "number"';
+    assert std.isNumber(value) : '"limit" expected to be of type "number"';
+
     {
-      limit: converted,
+      limit: value,
     }
   ),
+
   "#withQ":: "Searches the name property of groups for matching value",
   withQ(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"q" expected to be of type "string"';
+    assert std.isString(value) : '"q" expected to be of type "string"';
+
     {
-      q: converted,
+      q: value,
     }
   ),
+
   "#withSearch":: "Searches for groups with a supported filtering expression for all attributes except for '_embedded', '_links', and 'objectClass'",
   withSearch(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"search" expected to be of type "string"';
+    assert std.isString(value) : '"search" expected to be of type "string"';
+
     {
-      search: converted,
+      search: value,
     }
   ),
+
   "#withType":: "Type of the group. When specified in the terraform resource, will act as a filter when searching for the groups",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_idp_metadata_saml.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_idp_metadata_saml.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,19 +13,21 @@
       },
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIdpId":: "The id of the IdP to retrieve metadata for.",
   withIdpId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"idp_id" expected to be of type "string"';
+    assert std.isString(value) : '"idp_id" expected to be of type "string"';
+
     {
-      idp_id: converted,
+      idp_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_idp_oidc.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_idp_oidc.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,20 +13,22 @@
       },
     }
   ),
+
   "#withId":: "Id of idp.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Name of the idp.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_idp_saml.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_idp_saml.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,20 +13,22 @@
       },
     }
   ),
+
   "#withId":: "Id of idp.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Name of the idp.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_idp_social.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_idp_social.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,20 +13,22 @@
       },
     }
   ),
+
   "#withId":: "The id of the social idp to retrieve, conflicts with `name`.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "The name of the social idp to retrieve, conflicts with `id`.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_log_stream.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_log_stream.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,20 +13,22 @@
       },
     }
   ),
+
   "#withId":: "ID of the log stream to retrieve, conflicts with `name`.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Unique name for the Log Stream object, conflicts with `id`.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {
@@ -35,14 +38,15 @@
       },
     },
   },
+
   settings:: {
     local block = self,
+
     new():: (
       {}
     ),
   },
   withSettings(value):: (
-    local converted = value;
     {
       settings: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_network_zone.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_network_zone.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,68 +13,82 @@
       },
     }
   ),
+
   "#withDynamicLocationsExclude":: "Array of locations ISO-3166-1(2) excluded. Format code: countryCode OR countryCode-regionCode. Use with type `DYNAMIC_V2`",
   withDynamicLocationsExclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"dynamic_locations_exclude" expected to be of type "set"';
+
     {
       dynamic_locations_exclude: converted,
     }
   ),
+
   "#withDynamicLocationsExcludeMixin":: "Array of locations ISO-3166-1(2) excluded. Format code: countryCode OR countryCode-regionCode. Use with type `DYNAMIC_V2`",
   withDynamicLocationsExcludeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"dynamic_locations_exclude" expected to be of type "set"';
+
     {
       dynamic_locations_exclude+: converted,
     }
   ),
+
   "#withId":: "ID of the network zone to retrieve, conflicts with `name`.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIpServiceCategoriesExclude":: "List of ip service excluded. Use with type `DYNAMIC_V2`",
   withIpServiceCategoriesExclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"ip_service_categories_exclude" expected to be of type "set"';
+
     {
       ip_service_categories_exclude: converted,
     }
   ),
+
   "#withIpServiceCategoriesExcludeMixin":: "List of ip service excluded. Use with type `DYNAMIC_V2`",
   withIpServiceCategoriesExcludeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"ip_service_categories_exclude" expected to be of type "set"';
+
     {
       ip_service_categories_exclude+: converted,
     }
   ),
+
   "#withIpServiceCategoriesInclude":: "List of ip service included. Use with type `DYNAMIC_V2`",
   withIpServiceCategoriesInclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"ip_service_categories_include" expected to be of type "set"';
+
     {
       ip_service_categories_include: converted,
     }
   ),
+
   "#withIpServiceCategoriesIncludeMixin":: "List of ip service included. Use with type `DYNAMIC_V2`",
   withIpServiceCategoriesIncludeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"ip_service_categories_include" expected to be of type "set"';
+
     {
       ip_service_categories_include+: converted,
     }
   ),
+
   "#withName":: "Name of the network zone to retrieve, conflicts with `id`.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_org_metadata.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_org_metadata.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -19,26 +20,27 @@
       },
     },
   },
+
   domains:: {
     local block = self,
+
     new():: (
       {}
     ),
   },
   settings:: {
     local block = self,
+
     new():: (
       {}
     ),
   },
   withDomains(value):: (
-    local converted = value;
     {
       domains: value,
     }
   ),
   withSettings(value):: (
-    local converted = value;
     {
       settings: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_policy.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_policy.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name, type):: (
     {
       jsonnetTfMetadata:: {
@@ -14,27 +15,30 @@
     + block.withName(name)
     + block.withType(type)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Name of the policy",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withType":: "Policy type, see https://developer.okta.com/docs/reference/api/policy/#policy-object",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_realm.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_realm.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,28 +13,31 @@
       },
     }
   ),
+
   "#withId":: "The id of the Okta Realm.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "The name of the Okta Realm.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withRealmType":: "The realm type. Valid values: `PARTNER` and `DEFAULT`",
   withRealmType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"realm_type" expected to be of type "string"';
+    assert std.isString(value) : '"realm_type" expected to be of type "string"';
+
     {
-      realm_type: converted,
+      realm_type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_realm_assignment.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_realm_assignment.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,12 +13,13 @@
       },
     }
   ),
+
   "#withName":: "The name of the Okta Realm Assignment.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_role_subscription.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_role_subscription.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, notificationType, roleType):: (
     {
       jsonnetTfMetadata:: {
@@ -14,27 +15,30 @@
     + block.withNotificationType(notificationType)
     + block.withRoleType(roleType)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withNotificationType":: "Type of the notification",
   withNotificationType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"notification_type" expected to be of type "string"';
+    assert std.isString(value) : '"notification_type" expected to be of type "string"';
+
     {
-      notification_type: converted,
+      notification_type: value,
     }
   ),
+
   "#withRoleType":: "Type of the role",
   withRoleType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"role_type" expected to be of type "string"';
+    assert std.isString(value) : '"role_type" expected to be of type "string"';
+
     {
-      role_type: converted,
+      role_type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_theme.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_theme.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId, themeId):: (
     {
       jsonnetTfMetadata:: {
@@ -14,20 +15,22 @@
     + block.withBrandId(brandId)
     + block.withThemeId(themeId)
   ),
+
   "#withBrandId":: "Brand ID",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   "#withThemeId":: "Theme ID",
   withThemeId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"theme_id" expected to be of type "string"';
+    assert std.isString(value) : '"theme_id" expected to be of type "string"';
+
     {
-      theme_id: converted,
+      theme_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_themes.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_themes.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,19 +14,21 @@
     }
     + block.withBrandId(brandId)
   ),
+
   "#withBrandId":: "Brand ID",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_trusted_origins.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_trusted_origins.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,19 +13,21 @@
       },
     }
   ),
+
   "#withFilter":: "Filter criteria. Filter value will be URL-encoded by the provider",
   withFilter(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"filter" expected to be of type "string"';
+    assert std.isString(value) : '"filter" expected to be of type "string"';
+
     {
-      filter: converted,
+      filter: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_user.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_user.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,51 +13,57 @@
       },
     }
   ),
+
   "#withCompoundSearchOperator":: "Search operator used when joining multiple search clauses",
   withCompoundSearchOperator(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"compound_search_operator" expected to be of type "string"';
+    assert std.isString(value) : '"compound_search_operator" expected to be of type "string"';
+
     {
-      compound_search_operator: converted,
+      compound_search_operator: value,
     }
   ),
+
   "#withDelayReadSeconds":: "Force delay of the user read by N seconds. Useful when eventual consistency of user information needs to be allowed for.",
   withDelayReadSeconds(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"delay_read_seconds" expected to be of type "string"';
+    assert std.isString(value) : '"delay_read_seconds" expected to be of type "string"';
+
     {
-      delay_read_seconds: converted,
+      delay_read_seconds: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withSkipGroups":: "Do not populate user groups information (prevents additional API call)",
   withSkipGroups(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"skip_groups" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"skip_groups" expected to be of type "bool"';
+
     {
-      skip_groups: converted,
+      skip_groups: value,
     }
   ),
+
   "#withSkipRoles":: "Do not populate user roles information (prevents additional API call)",
   withSkipRoles(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"skip_roles" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"skip_roles" expected to be of type "bool"';
+
     {
-      skip_roles: converted,
+      skip_roles: value,
     }
   ),
+
   "#withUserId":: "Retrieve a single user based on their id",
   withUserId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_id" expected to be of type "string"';
+    assert std.isString(value) : '"user_id" expected to be of type "string"';
+
     {
-      user_id: converted,
+      user_id: value,
     }
   ),
   withTerraformName(value):: {
@@ -66,46 +73,52 @@
       },
     },
   },
+
   search:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withComparison(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"comparison" expected to be of type "string"';
+      assert std.isString(value) : '"comparison" expected to be of type "string"';
+
       {
-        comparison: converted,
+        comparison: value,
       }
     ),
+
     "#withExpression":: "A raw search expression string. This requires the search feature be on. Please see Okta documentation on their filter API for users. https://developer.okta.com/docs/api/resources/users#list-users-with-search",
     withExpression(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"expression" expected to be of type "string"';
+      assert std.isString(value) : '"expression" expected to be of type "string"';
+
       {
-        expression: converted,
+        expression: value,
       }
     ),
+
     "#withName":: "Property name to search for. This requires the search feature be on. Please see Okta documentation on their filter API for users. https://developer.okta.com/docs/api/resources/users#list-users-with-search",
     withName(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"name" expected to be of type "string"';
+      assert std.isString(value) : '"name" expected to be of type "string"';
+
       {
-        name: converted,
+        name: value,
       }
     ),
+
     withValue(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"value" expected to be of type "string"';
+      assert std.isString(value) : '"value" expected to be of type "string"';
+
       {
-        value: converted,
+        value: value,
       }
     ),
   },
   withSearch(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      search: value,
+      search: converted,
     }
   ),
   withSearchMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_user_profile_mapping_source.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_user_profile_mapping_source.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_user_security_questions.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_user_security_questions.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, userId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,19 +14,21 @@
     }
     + block.withUserId(userId)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withUserId":: "ID of a Okta User",
   withUserId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_id" expected to be of type "string"';
+    assert std.isString(value) : '"user_id" expected to be of type "string"';
+
     {
-      user_id: converted,
+      user_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_user_type.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_user_type.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,20 +13,22 @@
       },
     }
   ),
+
   "#withId":: "ID of the user type to retrieve, conflicts with `name`.",
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Name of user type to retrieve, conflicts with `id`.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/data_source/okta_users.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/data_source/okta_users.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,51 +13,57 @@
       },
     }
   ),
+
   "#withCompoundSearchOperator":: "Search operator used when joining multiple search clauses",
   withCompoundSearchOperator(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"compound_search_operator" expected to be of type "string"';
+    assert std.isString(value) : '"compound_search_operator" expected to be of type "string"';
+
     {
-      compound_search_operator: converted,
+      compound_search_operator: value,
     }
   ),
+
   "#withDelayReadSeconds":: "Force delay of the users read by N seconds. Useful when eventual consistency of users information needs to be allowed for.",
   withDelayReadSeconds(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"delay_read_seconds" expected to be of type "string"';
+    assert std.isString(value) : '"delay_read_seconds" expected to be of type "string"';
+
     {
-      delay_read_seconds: converted,
+      delay_read_seconds: value,
     }
   ),
+
   "#withGroupId":: "Find users based on group membership using the id of the group.",
   withGroupId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"group_id" expected to be of type "string"';
+    assert std.isString(value) : '"group_id" expected to be of type "string"';
+
     {
-      group_id: converted,
+      group_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIncludeGroups":: "Fetch group memberships for each user",
   withIncludeGroups(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"include_groups" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"include_groups" expected to be of type "bool"';
+
     {
-      include_groups: converted,
+      include_groups: value,
     }
   ),
+
   "#withIncludeRoles":: "Fetch user roles for each user",
   withIncludeRoles(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"include_roles" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"include_roles" expected to be of type "bool"';
+
     {
-      include_roles: converted,
+      include_roles: value,
     }
   ),
   withTerraformName(value):: {
@@ -66,46 +73,52 @@
       },
     },
   },
+
   search:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withComparison(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"comparison" expected to be of type "string"';
+      assert std.isString(value) : '"comparison" expected to be of type "string"';
+
       {
-        comparison: converted,
+        comparison: value,
       }
     ),
+
     "#withExpression":: "A raw search expression string. This requires the search feature be on. Please see Okta documentation on their filter API for users. https://developer.okta.com/docs/api/resources/users#list-users-with-search",
     withExpression(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"expression" expected to be of type "string"';
+      assert std.isString(value) : '"expression" expected to be of type "string"';
+
       {
-        expression: converted,
+        expression: value,
       }
     ),
+
     "#withName":: "Property name to search for. This requires the search feature be on. Please see Okta documentation on their filter API for users. https://developer.okta.com/docs/api/resources/users#list-users-with-search",
     withName(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"name" expected to be of type "string"';
+      assert std.isString(value) : '"name" expected to be of type "string"';
+
       {
-        name: converted,
+        name: value,
       }
     ),
+
     withValue(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"value" expected to be of type "string"';
+      assert std.isString(value) : '"value" expected to be of type "string"';
+
       {
-        value: converted,
+        value: value,
       }
     ),
   },
   withSearch(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      search: value,
+      search: converted,
     }
   ),
   withSearchMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/provider.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/provider.libsonnet
@@ -2,6 +2,7 @@
   version:: "~> 5.3.0",
   source:: "okta/okta",
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -14,146 +15,166 @@
       },
     }
   ),
+
   "#withAccessToken":: "Bearer token granting privileges to Okta API.",
   withAccessToken(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"access_token" expected to be of type "string"';
+    assert std.isString(value) : '"access_token" expected to be of type "string"';
+
     {
-      access_token: converted,
+      access_token: value,
     }
   ),
+
   "#withApiToken":: "API Token granting privileges to Okta API.",
   withApiToken(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"api_token" expected to be of type "string"';
+    assert std.isString(value) : '"api_token" expected to be of type "string"';
+
     {
-      api_token: converted,
+      api_token: value,
     }
   ),
+
   "#withBackoff":: "Use exponential back off strategy for rate limits.",
   withBackoff(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"backoff" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"backoff" expected to be of type "bool"';
+
     {
-      backoff: converted,
+      backoff: value,
     }
   ),
+
   "#withBaseUrl":: "The Okta url. (Use 'oktapreview.com' for Okta testing)",
   withBaseUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"base_url" expected to be of type "string"';
+    assert std.isString(value) : '"base_url" expected to be of type "string"';
+
     {
-      base_url: converted,
+      base_url: value,
     }
   ),
+
   "#withClientId":: "API Token granting privileges to Okta API.",
   withClientId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"client_id" expected to be of type "string"';
+    assert std.isString(value) : '"client_id" expected to be of type "string"';
+
     {
-      client_id: converted,
+      client_id: value,
     }
   ),
+
   "#withHttpProxy":: "Alternate HTTP proxy of scheme://hostname or scheme://hostname:port format",
   withHttpProxy(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"http_proxy" expected to be of type "string"';
+    assert std.isString(value) : '"http_proxy" expected to be of type "string"';
+
     {
-      http_proxy: converted,
+      http_proxy: value,
     }
   ),
+
   "#withLogLevel":: "providers log level. Minimum is 1 (TRACE), and maximum is 5 (ERROR)",
   withLogLevel(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"log_level" expected to be of type "number"';
+    assert std.isNumber(value) : '"log_level" expected to be of type "number"';
+
     {
-      log_level: converted,
+      log_level: value,
     }
   ),
+
   "#withMaxApiCapacity":: "Sets what percentage of capacity the provider can use of the total rate limit capacity while making calls to the Okta management API endpoints. Okta API operates in one minute buckets. See Okta Management API Rate Limits: https://developer.okta.com/docs/reference/rl-global-mgmt/",
   withMaxApiCapacity(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"max_api_capacity" expected to be of type "number"';
+    assert std.isNumber(value) : '"max_api_capacity" expected to be of type "number"';
+
     {
-      max_api_capacity: converted,
+      max_api_capacity: value,
     }
   ),
+
   "#withMaxRetries":: "maximum number of retries to attempt before erroring out.",
   withMaxRetries(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"max_retries" expected to be of type "number"';
+    assert std.isNumber(value) : '"max_retries" expected to be of type "number"';
+
     {
-      max_retries: converted,
+      max_retries: value,
     }
   ),
+
   "#withMaxWaitSeconds":: "maximum seconds to wait when rate limit is hit. We use exponential backoffs when backoff is enabled.",
   withMaxWaitSeconds(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"max_wait_seconds" expected to be of type "number"';
+    assert std.isNumber(value) : '"max_wait_seconds" expected to be of type "number"';
+
     {
-      max_wait_seconds: converted,
+      max_wait_seconds: value,
     }
   ),
+
   "#withMinWaitSeconds":: "minimum seconds to wait when rate limit is hit. We use exponential backoffs when backoff is enabled.",
   withMinWaitSeconds(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"min_wait_seconds" expected to be of type "number"';
+    assert std.isNumber(value) : '"min_wait_seconds" expected to be of type "number"';
+
     {
-      min_wait_seconds: converted,
+      min_wait_seconds: value,
     }
   ),
+
   "#withOrgName":: "The organization to manage in Okta.",
   withOrgName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"org_name" expected to be of type "string"';
+    assert std.isString(value) : '"org_name" expected to be of type "string"';
+
     {
-      org_name: converted,
+      org_name: value,
     }
   ),
+
   "#withParallelism":: "Number of concurrent requests to make within a resource where bulk operations are not possible. Take note of https://developer.okta.com/docs/api/getting_started/rate-limits.",
   withParallelism(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"parallelism" expected to be of type "number"';
+    assert std.isNumber(value) : '"parallelism" expected to be of type "number"';
+
     {
-      parallelism: converted,
+      parallelism: value,
     }
   ),
+
   "#withPrivateKey":: "API Token granting privileges to Okta API.",
   withPrivateKey(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"private_key" expected to be of type "string"';
+    assert std.isString(value) : '"private_key" expected to be of type "string"';
+
     {
-      private_key: converted,
+      private_key: value,
     }
   ),
+
   "#withPrivateKeyId":: "API Token Id granting privileges to Okta API.",
   withPrivateKeyId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"private_key_id" expected to be of type "string"';
+    assert std.isString(value) : '"private_key_id" expected to be of type "string"';
+
     {
-      private_key_id: converted,
+      private_key_id: value,
     }
   ),
+
   "#withRequestTimeout":: "Timeout for single request (in seconds) which is made to Okta, the default is `0` (means no limit is set). The maximum value can be `300`.",
   withRequestTimeout(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"request_timeout" expected to be of type "number"';
+    assert std.isNumber(value) : '"request_timeout" expected to be of type "number"';
+
     {
-      request_timeout: converted,
+      request_timeout: value,
     }
   ),
+
   "#withScopes":: "API Token granting privileges to Okta API.",
   withScopes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"scopes" expected to be of type "set"';
+
     {
       scopes: converted,
     }
   ),
+
   "#withScopesMixin":: "API Token granting privileges to Okta API.",
   withScopesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"scopes" expected to be of type "set"';
+
     {
       scopes+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_admin_role_custom.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_admin_role_custom.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, description, label):: (
     {
       jsonnetTfMetadata:: {
@@ -14,41 +15,48 @@
     + block.withDescription(description)
     + block.withLabel(label)
   ),
+
   "#withDescription":: "A human-readable description of the new Role",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLabel":: "The name given to the new Role",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withPermissions":: "The permissions that the new Role grants. At least one \t\t\t\tpermission must be specified when creating custom role. Valid values: 'okta.users.manage', \t\t\t\t'okta.users.create', \t\t\t\t'okta.users.read', \t\t\t\t'okta.users.credentials.manage', \t\t\t\t'okta.users.credentials.resetFactors', \t\t\t\t'okta.users.credentials.resetPassword', \t\t\t\t'okta.users.credentials.expirePassword', \t\t\t\t'okta.users.userprofile.manage', \t\t\t\t'okta.users.lifecycle.manage', \t\t\t\t'okta.users.lifecycle.activate', \t\t\t\t'okta.users.lifecycle.deactivate', \t\t\t\t'okta.users.lifecycle.suspend', \t\t\t\t'okta.users.lifecycle.unsuspend', \t\t\t\t'okta.users.lifecycle.delete', \t\t\t\t'okta.users.lifecycle.unlock', \t\t\t\t'okta.users.lifecycle.clearSessions', \t\t\t\t'okta.users.groupMembership.manage', \t\t\t\t'okta.users.appAssignment.manage', \t\t\t\t'okta.users.apitokens.manage', \t\t\t\t'okta.users.apitokens.read', \t\t\t\t'okta.groups.manage', \t\t\t\t'okta.groups.create', \t\t\t\t'okta.groups.members.manage', \t\t\t\t'okta.groups.read', \t\t\t\t'okta.groups.appAssignment.manage', \t\t\t\t'okta.apps.read', \t\t\t\t'okta.apps.manage', \t\t\t\t'okta.apps.assignment.manage', \t\t\t\t'okta.profilesources.import.run', \t\t\t\t'okta.authzServers.read', \t\t\t\t'okta.users.userprofile.manage', \t\t\t\t'okta.authzServers.manage', \t\t\t\t'okta.customizations.read', \t\t\t\t'okta.customizations.manage', \t\t\t\t'okta.identityProviders.read', \t\t\t\t'okta.identityProviders.manage', \t\t\t\t'okta.workflows.read', \t\t\t\t'okta.workflows.invoke'. \t\t\t\t'okta.governance.accessCertifications.manage', \t\t\t\t'okta.governance.accessRequests.manage', \t\t\t\t'okta.apps.manageFirstPartyApps', \t\t\t\t'okta.agents.manage', \t\t\t\t'okta.agents.register', \t\t\t\t'okta.agents.view', \t\t\t\t'okta.directories.manage', \t\t\t\t'okta.directories.read', \t\t\t\t'okta.devices.manage', \t\t\t\t'okta.devices.lifecycle.manage', \t\t\t\t'okta.devices.lifecycle.activate', \t\t\t\t'okta.devices.lifecycle.deactivate', \t\t\t\t'okta.devices.lifecycle.suspend', \t\t\t\t'okta.devices.lifecycle.unsuspend', \t\t\t\t'okta.devices.lifecycle.delete', \t\t\t\t'okta.devices.read', \t\t\t\t'okta.iam.read', \t\t\t\t'okta.support.cases.manage'.,",
   withPermissions(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"permissions" expected to be of type "set"';
+
     {
       permissions: converted,
     }
   ),
+
   "#withPermissionsMixin":: "The permissions that the new Role grants. At least one \t\t\t\tpermission must be specified when creating custom role. Valid values: 'okta.users.manage', \t\t\t\t'okta.users.create', \t\t\t\t'okta.users.read', \t\t\t\t'okta.users.credentials.manage', \t\t\t\t'okta.users.credentials.resetFactors', \t\t\t\t'okta.users.credentials.resetPassword', \t\t\t\t'okta.users.credentials.expirePassword', \t\t\t\t'okta.users.userprofile.manage', \t\t\t\t'okta.users.lifecycle.manage', \t\t\t\t'okta.users.lifecycle.activate', \t\t\t\t'okta.users.lifecycle.deactivate', \t\t\t\t'okta.users.lifecycle.suspend', \t\t\t\t'okta.users.lifecycle.unsuspend', \t\t\t\t'okta.users.lifecycle.delete', \t\t\t\t'okta.users.lifecycle.unlock', \t\t\t\t'okta.users.lifecycle.clearSessions', \t\t\t\t'okta.users.groupMembership.manage', \t\t\t\t'okta.users.appAssignment.manage', \t\t\t\t'okta.users.apitokens.manage', \t\t\t\t'okta.users.apitokens.read', \t\t\t\t'okta.groups.manage', \t\t\t\t'okta.groups.create', \t\t\t\t'okta.groups.members.manage', \t\t\t\t'okta.groups.read', \t\t\t\t'okta.groups.appAssignment.manage', \t\t\t\t'okta.apps.read', \t\t\t\t'okta.apps.manage', \t\t\t\t'okta.apps.assignment.manage', \t\t\t\t'okta.profilesources.import.run', \t\t\t\t'okta.authzServers.read', \t\t\t\t'okta.users.userprofile.manage', \t\t\t\t'okta.authzServers.manage', \t\t\t\t'okta.customizations.read', \t\t\t\t'okta.customizations.manage', \t\t\t\t'okta.identityProviders.read', \t\t\t\t'okta.identityProviders.manage', \t\t\t\t'okta.workflows.read', \t\t\t\t'okta.workflows.invoke'. \t\t\t\t'okta.governance.accessCertifications.manage', \t\t\t\t'okta.governance.accessRequests.manage', \t\t\t\t'okta.apps.manageFirstPartyApps', \t\t\t\t'okta.agents.manage', \t\t\t\t'okta.agents.register', \t\t\t\t'okta.agents.view', \t\t\t\t'okta.directories.manage', \t\t\t\t'okta.directories.read', \t\t\t\t'okta.devices.manage', \t\t\t\t'okta.devices.lifecycle.manage', \t\t\t\t'okta.devices.lifecycle.activate', \t\t\t\t'okta.devices.lifecycle.deactivate', \t\t\t\t'okta.devices.lifecycle.suspend', \t\t\t\t'okta.devices.lifecycle.unsuspend', \t\t\t\t'okta.devices.lifecycle.delete', \t\t\t\t'okta.devices.read', \t\t\t\t'okta.iam.read', \t\t\t\t'okta.support.cases.manage'.,",
   withPermissionsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"permissions" expected to be of type "set"';
+
     {
       permissions+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_admin_role_custom_assignments.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_admin_role_custom_assignments.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, customRoleId, resourceSetId):: (
     {
       jsonnetTfMetadata:: {
@@ -14,43 +15,50 @@
     + block.withCustomRoleId(customRoleId)
     + block.withResourceSetId(resourceSetId)
   ),
+
   "#withCustomRoleId":: "ID of the Custom Role",
   withCustomRoleId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"custom_role_id" expected to be of type "string"';
+    assert std.isString(value) : '"custom_role_id" expected to be of type "string"';
+
     {
-      custom_role_id: converted,
+      custom_role_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withMembers":: "The hrefs that point to User(s) and/or Group(s) that receive the Role",
   withMembers(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"members" expected to be of type "set"';
+
     {
       members: converted,
     }
   ),
+
   "#withMembersMixin":: "The hrefs that point to User(s) and/or Group(s) that receive the Role",
   withMembersMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"members" expected to be of type "set"';
+
     {
       members+: converted,
     }
   ),
+
   "#withResourceSetId":: "ID of the target Resource Set",
   withResourceSetId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"resource_set_id" expected to be of type "string"';
+    assert std.isString(value) : '"resource_set_id" expected to be of type "string"';
+
     {
-      resource_set_id: converted,
+      resource_set_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_admin_role_targets.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_admin_role_targets.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, roleType, userId):: (
     {
       jsonnetTfMetadata:: {
@@ -14,59 +15,70 @@
     + block.withRoleType(roleType)
     + block.withUserId(userId)
   ),
+
   "#withApps":: "List of app names (name represents set of app instances) or a combination of app name and app instance ID (like 'salesforce' or 'facebook.0oapsqQ6dv19pqyEo0g3')",
   withApps(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"apps" expected to be of type "set"';
+
     {
       apps: converted,
     }
   ),
+
   "#withAppsMixin":: "List of app names (name represents set of app instances) or a combination of app name and app instance ID (like 'salesforce' or 'facebook.0oapsqQ6dv19pqyEo0g3')",
   withAppsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"apps" expected to be of type "set"';
+
     {
       apps+: converted,
     }
   ),
+
   "#withGroups":: "List of group IDs. Conflicts with apps",
   withGroups(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups" expected to be of type "set"';
+
     {
       groups: converted,
     }
   ),
+
   "#withGroupsMixin":: "List of group IDs. Conflicts with apps",
   withGroupsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups" expected to be of type "set"';
+
     {
       groups+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withRoleType":: "Type of the role that is assigned to the user and supports optional targets. See [API Docs](https://developer.okta.com/docs/api/openapi/okta-management/guides/roles/#standard-roles)",
   withRoleType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"role_type" expected to be of type "string"';
+    assert std.isString(value) : '"role_type" expected to be of type "string"';
+
     {
-      role_type: converted,
+      role_type: value,
     }
   ),
+
   "#withUserId":: "User associated with the role",
   withUserId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_id" expected to be of type "string"';
+    assert std.isString(value) : '"user_id" expected to be of type "string"';
+
     {
-      user_id: converted,
+      user_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_access_policy_assignment.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_access_policy_assignment.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, appId, policyId):: (
     {
       jsonnetTfMetadata:: {
@@ -14,20 +15,22 @@
     + block.withAppId(appId)
     + block.withPolicyId(policyId)
   ),
+
   "#withAppId":: "The application ID; this value is immutable and can not be updated.",
   withAppId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_id" expected to be of type "string"';
+    assert std.isString(value) : '"app_id" expected to be of type "string"';
+
     {
-      app_id: converted,
+      app_id: value,
     }
   ),
+
   "#withPolicyId":: "The access policy ID.",
   withPolicyId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"policy_id" expected to be of type "string"';
+    assert std.isString(value) : '"policy_id" expected to be of type "string"';
+
     {
-      policy_id: converted,
+      policy_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_auto_login.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_auto_login.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, label):: (
     {
       jsonnetTfMetadata:: {
@@ -13,203 +14,228 @@
     }
     + block.withLabel(label)
   ),
+
   "#withAccessibilityErrorRedirectUrl":: "Custom error page URL",
   withAccessibilityErrorRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_error_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_error_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_error_redirect_url: converted,
+      accessibility_error_redirect_url: value,
     }
   ),
+
   "#withAccessibilityLoginRedirectUrl":: "Custom login page URL",
   withAccessibilityLoginRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_login_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_login_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_login_redirect_url: converted,
+      accessibility_login_redirect_url: value,
     }
   ),
+
   "#withAccessibilitySelfService":: "Enable self service. Default is `false`",
   withAccessibilitySelfService(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"accessibility_self_service" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"accessibility_self_service" expected to be of type "bool"';
+
     {
-      accessibility_self_service: converted,
+      accessibility_self_service: value,
     }
   ),
+
   "#withAdminNote":: "Application notes for admins.",
   withAdminNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"admin_note" expected to be of type "string"';
+    assert std.isString(value) : '"admin_note" expected to be of type "string"';
+
     {
-      admin_note: converted,
+      admin_note: value,
     }
   ),
+
   "#withAppLinksJson":: "Displays specific appLinks for the app. The value for each application link should be boolean.",
   withAppLinksJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_links_json" expected to be of type "string"';
+    assert std.isString(value) : '"app_links_json" expected to be of type "string"';
+
     {
-      app_links_json: converted,
+      app_links_json: value,
     }
   ),
+
   "#withAppSettingsJson":: "Application settings in JSON format",
   withAppSettingsJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_settings_json" expected to be of type "string"';
+    assert std.isString(value) : '"app_settings_json" expected to be of type "string"';
+
     {
-      app_settings_json: converted,
+      app_settings_json: value,
     }
   ),
+
   "#withAutoSubmitToolbar":: "Display auto submit toolbar",
   withAutoSubmitToolbar(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"auto_submit_toolbar" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"auto_submit_toolbar" expected to be of type "bool"';
+
     {
-      auto_submit_toolbar: converted,
+      auto_submit_toolbar: value,
     }
   ),
+
   "#withCredentialsScheme":: "Application credentials scheme. One of: `EDIT_USERNAME_AND_PASSWORD`, `ADMIN_SETS_CREDENTIALS`, `EDIT_PASSWORD_ONLY`, `EXTERNAL_PASSWORD_SYNC`, or `SHARED_USERNAME_AND_PASSWORD`",
   withCredentialsScheme(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"credentials_scheme" expected to be of type "string"';
+    assert std.isString(value) : '"credentials_scheme" expected to be of type "string"';
+
     {
-      credentials_scheme: converted,
+      credentials_scheme: value,
     }
   ),
+
   "#withEnduserNote":: "Application notes for end users.",
   withEnduserNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"enduser_note" expected to be of type "string"';
+    assert std.isString(value) : '"enduser_note" expected to be of type "string"';
+
     {
-      enduser_note: converted,
+      enduser_note: value,
     }
   ),
+
   "#withHideIos":: "Do not display application icon on mobile app",
   withHideIos(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_ios" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_ios" expected to be of type "bool"';
+
     {
-      hide_ios: converted,
+      hide_ios: value,
     }
   ),
+
   "#withHideWeb":: "Do not display application icon to users",
   withHideWeb(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_web" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_web" expected to be of type "bool"';
+
     {
-      hide_web: converted,
+      hide_web: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLabel":: "The Application's display name.",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withLogo":: "Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.",
   withLogo(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"logo" expected to be of type "string"';
+    assert std.isString(value) : '"logo" expected to be of type "string"';
+
     {
-      logo: converted,
+      logo: value,
     }
   ),
+
   "#withPreconfiguredApp":: "Tells Okta to use an existing application in their application catalog, as opposed to a custom application.",
   withPreconfiguredApp(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"preconfigured_app" expected to be of type "string"';
+    assert std.isString(value) : '"preconfigured_app" expected to be of type "string"';
+
     {
-      preconfigured_app: converted,
+      preconfigured_app: value,
     }
   ),
+
   "#withRevealPassword":: "Allow user to reveal password. Default is false. It can not be set to true if credentials_scheme is 'ADMIN_SETS_CREDENTIALS', 'SHARED_USERNAME_AND_PASSWORD' or 'EXTERNAL_PASSWORD_SYNC'.",
   withRevealPassword(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"reveal_password" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"reveal_password" expected to be of type "bool"';
+
     {
-      reveal_password: converted,
+      reveal_password: value,
     }
   ),
+
   "#withSharedPassword":: "Shared password, required for certain schemes.",
   withSharedPassword(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"shared_password" expected to be of type "string"';
+    assert std.isString(value) : '"shared_password" expected to be of type "string"';
+
     {
-      shared_password: converted,
+      shared_password: value,
     }
   ),
+
   "#withSharedUsername":: "Shared username, required for certain schemes.",
   withSharedUsername(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"shared_username" expected to be of type "string"';
+    assert std.isString(value) : '"shared_username" expected to be of type "string"';
+
     {
-      shared_username: converted,
+      shared_username: value,
     }
   ),
+
   "#withSignOnRedirectUrl":: "Post login redirect URL",
   withSignOnRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"sign_on_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"sign_on_redirect_url" expected to be of type "string"';
+
     {
-      sign_on_redirect_url: converted,
+      sign_on_redirect_url: value,
     }
   ),
+
   "#withSignOnUrl":: "Login URL",
   withSignOnUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"sign_on_url" expected to be of type "string"';
+    assert std.isString(value) : '"sign_on_url" expected to be of type "string"';
+
     {
-      sign_on_url: converted,
+      sign_on_url: value,
     }
   ),
+
   "#withStatus":: "Status of application. By default, it is `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withUserNameTemplate":: "Username template. Default: `${source.login}`",
   withUserNameTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template" expected to be of type "string"';
+
     {
-      user_name_template: converted,
+      user_name_template: value,
     }
   ),
+
   "#withUserNameTemplatePushStatus":: "Push username on update. Valid values: `PUSH` and `DONT_PUSH`",
   withUserNameTemplatePushStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_push_status" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_push_status" expected to be of type "string"';
+
     {
-      user_name_template_push_status: converted,
+      user_name_template_push_status: value,
     }
   ),
+
   "#withUserNameTemplateSuffix":: "Username template suffix",
   withUserNameTemplateSuffix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_suffix" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_suffix" expected to be of type "string"';
+
     {
-      user_name_template_suffix: converted,
+      user_name_template_suffix: value,
     }
   ),
+
   "#withUserNameTemplateType":: "Username template type. Default: `BUILT_IN`",
   withUserNameTemplateType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_type" expected to be of type "string"';
+
     {
-      user_name_template_type: converted,
+      user_name_template_type: value,
     }
   ),
   withTerraformName(value):: {
@@ -219,35 +245,39 @@
       },
     },
   },
+
   timeouts:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withCreate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"create" expected to be of type "string"';
+      assert std.isString(value) : '"create" expected to be of type "string"';
+
       {
-        create: converted,
+        create: value,
       }
     ),
+
     withRead(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"read" expected to be of type "string"';
+      assert std.isString(value) : '"read" expected to be of type "string"';
+
       {
-        read: converted,
+        read: value,
       }
     ),
+
     withUpdate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"update" expected to be of type "string"';
+      assert std.isString(value) : '"update" expected to be of type "string"';
+
       {
-        update: converted,
+        update: value,
       }
     ),
   },
   withTimeouts(value):: (
-    local converted = value;
     {
       timeouts: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_basic_auth.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_basic_auth.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, authUrl, label, url):: (
     {
       jsonnetTfMetadata:: {
@@ -15,187 +16,210 @@
     + block.withLabel(label)
     + block.withUrl(url)
   ),
+
   "#withAccessibilityErrorRedirectUrl":: "Custom error page URL",
   withAccessibilityErrorRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_error_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_error_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_error_redirect_url: converted,
+      accessibility_error_redirect_url: value,
     }
   ),
+
   "#withAccessibilityLoginRedirectUrl":: "Custom login page URL",
   withAccessibilityLoginRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_login_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_login_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_login_redirect_url: converted,
+      accessibility_login_redirect_url: value,
     }
   ),
+
   "#withAccessibilitySelfService":: "Enable self service. Default is `false`",
   withAccessibilitySelfService(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"accessibility_self_service" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"accessibility_self_service" expected to be of type "bool"';
+
     {
-      accessibility_self_service: converted,
+      accessibility_self_service: value,
     }
   ),
+
   "#withAdminNote":: "Application notes for admins.",
   withAdminNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"admin_note" expected to be of type "string"';
+    assert std.isString(value) : '"admin_note" expected to be of type "string"';
+
     {
-      admin_note: converted,
+      admin_note: value,
     }
   ),
+
   "#withAppLinksJson":: "Displays specific appLinks for the app. The value for each application link should be boolean.",
   withAppLinksJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_links_json" expected to be of type "string"';
+    assert std.isString(value) : '"app_links_json" expected to be of type "string"';
+
     {
-      app_links_json: converted,
+      app_links_json: value,
     }
   ),
+
   "#withAuthUrl":: "The URL of the authenticating site for this app.",
   withAuthUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"auth_url" expected to be of type "string"';
+    assert std.isString(value) : '"auth_url" expected to be of type "string"';
+
     {
-      auth_url: converted,
+      auth_url: value,
     }
   ),
+
   "#withAutoSubmitToolbar":: "Display auto submit toolbar",
   withAutoSubmitToolbar(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"auto_submit_toolbar" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"auto_submit_toolbar" expected to be of type "bool"';
+
     {
-      auto_submit_toolbar: converted,
+      auto_submit_toolbar: value,
     }
   ),
+
   "#withCredentialsScheme":: "Application credentials scheme. One of: `EDIT_USERNAME_AND_PASSWORD`, `ADMIN_SETS_CREDENTIALS`, `EDIT_PASSWORD_ONLY`, `EXTERNAL_PASSWORD_SYNC`, or `SHARED_USERNAME_AND_PASSWORD`",
   withCredentialsScheme(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"credentials_scheme" expected to be of type "string"';
+    assert std.isString(value) : '"credentials_scheme" expected to be of type "string"';
+
     {
-      credentials_scheme: converted,
+      credentials_scheme: value,
     }
   ),
+
   "#withEnduserNote":: "Application notes for end users.",
   withEnduserNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"enduser_note" expected to be of type "string"';
+    assert std.isString(value) : '"enduser_note" expected to be of type "string"';
+
     {
-      enduser_note: converted,
+      enduser_note: value,
     }
   ),
+
   "#withHideIos":: "Do not display application icon on mobile app",
   withHideIos(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_ios" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_ios" expected to be of type "bool"';
+
     {
-      hide_ios: converted,
+      hide_ios: value,
     }
   ),
+
   "#withHideWeb":: "Do not display application icon to users",
   withHideWeb(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_web" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_web" expected to be of type "bool"';
+
     {
-      hide_web: converted,
+      hide_web: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLabel":: "The Application's display name.",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withLogo":: "Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.",
   withLogo(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"logo" expected to be of type "string"';
+    assert std.isString(value) : '"logo" expected to be of type "string"';
+
     {
-      logo: converted,
+      logo: value,
     }
   ),
+
   "#withRevealPassword":: "Allow user to reveal password. Default is false. It can not be set to true if credentials_scheme is 'ADMIN_SETS_CREDENTIALS', 'SHARED_USERNAME_AND_PASSWORD' or 'EXTERNAL_PASSWORD_SYNC'.",
   withRevealPassword(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"reveal_password" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"reveal_password" expected to be of type "bool"';
+
     {
-      reveal_password: converted,
+      reveal_password: value,
     }
   ),
+
   "#withSharedPassword":: "Shared password, required for certain schemes.",
   withSharedPassword(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"shared_password" expected to be of type "string"';
+    assert std.isString(value) : '"shared_password" expected to be of type "string"';
+
     {
-      shared_password: converted,
+      shared_password: value,
     }
   ),
+
   "#withSharedUsername":: "Shared username, required for certain schemes.",
   withSharedUsername(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"shared_username" expected to be of type "string"';
+    assert std.isString(value) : '"shared_username" expected to be of type "string"';
+
     {
-      shared_username: converted,
+      shared_username: value,
     }
   ),
+
   "#withStatus":: "Status of application. By default, it is `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withUrl":: "The URL of the sign-in page for this app.",
   withUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"url" expected to be of type "string"';
+    assert std.isString(value) : '"url" expected to be of type "string"';
+
     {
-      url: converted,
+      url: value,
     }
   ),
+
   "#withUserNameTemplate":: "Username template. Default: `${source.login}`",
   withUserNameTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template" expected to be of type "string"';
+
     {
-      user_name_template: converted,
+      user_name_template: value,
     }
   ),
+
   "#withUserNameTemplatePushStatus":: "Push username on update. Valid values: `PUSH`, `DONT_PUSH` and `NOT_CONFIGURED`",
   withUserNameTemplatePushStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_push_status" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_push_status" expected to be of type "string"';
+
     {
-      user_name_template_push_status: converted,
+      user_name_template_push_status: value,
     }
   ),
+
   "#withUserNameTemplateSuffix":: "Username template suffix",
   withUserNameTemplateSuffix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_suffix" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_suffix" expected to be of type "string"';
+
     {
-      user_name_template_suffix: converted,
+      user_name_template_suffix: value,
     }
   ),
+
   "#withUserNameTemplateType":: "Username template type. Default: `BUILT_IN`. Valid values: `NONE`, `CUSTOM`, `BUILT_IN`",
   withUserNameTemplateType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_type" expected to be of type "string"';
+
     {
-      user_name_template_type: converted,
+      user_name_template_type: value,
     }
   ),
   withTerraformName(value):: {
@@ -205,35 +229,39 @@
       },
     },
   },
+
   timeouts:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withCreate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"create" expected to be of type "string"';
+      assert std.isString(value) : '"create" expected to be of type "string"';
+
       {
-        create: converted,
+        create: value,
       }
     ),
+
     withRead(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"read" expected to be of type "string"';
+      assert std.isString(value) : '"read" expected to be of type "string"';
+
       {
-        read: converted,
+        read: value,
       }
     ),
+
     withUpdate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"update" expected to be of type "string"';
+      assert std.isString(value) : '"update" expected to be of type "string"';
+
       {
-        update: converted,
+        update: value,
       }
     ),
   },
   withTimeouts(value):: (
-    local converted = value;
     {
       timeouts: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_bookmark.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_bookmark.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, label, url):: (
     {
       jsonnetTfMetadata:: {
@@ -14,131 +15,147 @@
     + block.withLabel(label)
     + block.withUrl(url)
   ),
+
   "#withAccessibilityErrorRedirectUrl":: "Custom error page URL",
   withAccessibilityErrorRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_error_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_error_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_error_redirect_url: converted,
+      accessibility_error_redirect_url: value,
     }
   ),
+
   "#withAccessibilityLoginRedirectUrl":: "Custom login page URL",
   withAccessibilityLoginRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_login_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_login_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_login_redirect_url: converted,
+      accessibility_login_redirect_url: value,
     }
   ),
+
   "#withAccessibilitySelfService":: "Enable self service. Default is `false`",
   withAccessibilitySelfService(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"accessibility_self_service" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"accessibility_self_service" expected to be of type "bool"';
+
     {
-      accessibility_self_service: converted,
+      accessibility_self_service: value,
     }
   ),
+
   "#withAdminNote":: "Application notes for admins.",
   withAdminNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"admin_note" expected to be of type "string"';
+    assert std.isString(value) : '"admin_note" expected to be of type "string"';
+
     {
-      admin_note: converted,
+      admin_note: value,
     }
   ),
+
   "#withAppLinksJson":: "Displays specific appLinks for the app. The value for each application link should be boolean.",
   withAppLinksJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_links_json" expected to be of type "string"';
+    assert std.isString(value) : '"app_links_json" expected to be of type "string"';
+
     {
-      app_links_json: converted,
+      app_links_json: value,
     }
   ),
+
   "#withAuthenticationPolicy":: "The ID of the associated app_signon_policy. If this property is removed from the application the default sign-on-policy will be associated with this application.",
   withAuthenticationPolicy(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"authentication_policy" expected to be of type "string"';
+    assert std.isString(value) : '"authentication_policy" expected to be of type "string"';
+
     {
-      authentication_policy: converted,
+      authentication_policy: value,
     }
   ),
+
   "#withAutoSubmitToolbar":: "Display auto submit toolbar",
   withAutoSubmitToolbar(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"auto_submit_toolbar" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"auto_submit_toolbar" expected to be of type "bool"';
+
     {
-      auto_submit_toolbar: converted,
+      auto_submit_toolbar: value,
     }
   ),
+
   "#withEnduserNote":: "Application notes for end users.",
   withEnduserNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"enduser_note" expected to be of type "string"';
+    assert std.isString(value) : '"enduser_note" expected to be of type "string"';
+
     {
-      enduser_note: converted,
+      enduser_note: value,
     }
   ),
+
   "#withHideIos":: "Do not display application icon on mobile app",
   withHideIos(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_ios" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_ios" expected to be of type "bool"';
+
     {
-      hide_ios: converted,
+      hide_ios: value,
     }
   ),
+
   "#withHideWeb":: "Do not display application icon to users",
   withHideWeb(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_web" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_web" expected to be of type "bool"';
+
     {
-      hide_web: converted,
+      hide_web: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLabel":: "The Application's display name.",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withLogo":: "Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.",
   withLogo(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"logo" expected to be of type "string"';
+    assert std.isString(value) : '"logo" expected to be of type "string"';
+
     {
-      logo: converted,
+      logo: value,
     }
   ),
+
   "#withRequestIntegration":: "Would you like Okta to add an integration for this app?",
   withRequestIntegration(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"request_integration" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"request_integration" expected to be of type "bool"';
+
     {
-      request_integration: converted,
+      request_integration: value,
     }
   ),
+
   "#withStatus":: "Status of application. By default, it is `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withUrl":: "The URL of the bookmark.",
   withUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"url" expected to be of type "string"';
+    assert std.isString(value) : '"url" expected to be of type "string"';
+
     {
-      url: converted,
+      url: value,
     }
   ),
   withTerraformName(value):: {
@@ -148,35 +165,39 @@
       },
     },
   },
+
   timeouts:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withCreate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"create" expected to be of type "string"';
+      assert std.isString(value) : '"create" expected to be of type "string"';
+
       {
-        create: converted,
+        create: value,
       }
     ),
+
     withRead(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"read" expected to be of type "string"';
+      assert std.isString(value) : '"read" expected to be of type "string"';
+
       {
-        read: converted,
+        read: value,
       }
     ),
+
     withUpdate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"update" expected to be of type "string"';
+      assert std.isString(value) : '"update" expected to be of type "string"';
+
       {
-        update: converted,
+        update: value,
       }
     ),
   },
   withTimeouts(value):: (
-    local converted = value;
     {
       timeouts: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_group_assignment.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_group_assignment.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, appId, groupId):: (
     {
       jsonnetTfMetadata:: {
@@ -14,51 +15,57 @@
     + block.withAppId(appId)
     + block.withGroupId(groupId)
   ),
+
   "#withAppId":: "App to associate group with",
   withAppId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_id" expected to be of type "string"';
+    assert std.isString(value) : '"app_id" expected to be of type "string"';
+
     {
-      app_id: converted,
+      app_id: value,
     }
   ),
+
   "#withGroupId":: "Group associated with the application",
   withGroupId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"group_id" expected to be of type "string"';
+    assert std.isString(value) : '"group_id" expected to be of type "string"';
+
     {
-      group_id: converted,
+      group_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withPriority":: "Priority of group assignment.",
   withPriority(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+    assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
     {
-      priority: converted,
+      priority: value,
     }
   ),
+
   "#withProfile":: "JSON document containing [application profile](https://developer.okta.com/docs/reference/api/apps/#profile-object)",
   withProfile(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"profile" expected to be of type "string"';
+    assert std.isString(value) : '"profile" expected to be of type "string"';
+
     {
-      profile: converted,
+      profile: value,
     }
   ),
+
   "#withRetainAssignment":: "Retain the group assignment on destroy. If set to true, the resource will be removed from state but not from the Okta app.",
   withRetainAssignment(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"retain_assignment" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"retain_assignment" expected to be of type "bool"';
+
     {
-      retain_assignment: converted,
+      retain_assignment: value,
     }
   ),
   withTerraformName(value):: {
@@ -68,35 +75,39 @@
       },
     },
   },
+
   timeouts:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withCreate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"create" expected to be of type "string"';
+      assert std.isString(value) : '"create" expected to be of type "string"';
+
       {
-        create: converted,
+        create: value,
       }
     ),
+
     withRead(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"read" expected to be of type "string"';
+      assert std.isString(value) : '"read" expected to be of type "string"';
+
       {
-        read: converted,
+        read: value,
       }
     ),
+
     withUpdate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"update" expected to be of type "string"';
+      assert std.isString(value) : '"update" expected to be of type "string"';
+
       {
-        update: converted,
+        update: value,
       }
     ),
   },
   withTimeouts(value):: (
-    local converted = value;
     {
       timeouts: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_group_assignments.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_group_assignments.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, appId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,19 +14,21 @@
     }
     + block.withAppId(appId)
   ),
+
   "#withAppId":: "The ID of the application to assign a group to.",
   withAppId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_id" expected to be of type "string"';
+    assert std.isString(value) : '"app_id" expected to be of type "string"';
+
     {
-      app_id: converted,
+      app_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {
@@ -35,72 +38,80 @@
       },
     },
   },
+
   group:: {
     local block = self,
+
     new(id):: (
       {}
       + block.withId(id)
     ),
+
     "#withId":: "A group to associate with the application",
     withId(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"id" expected to be of type "string"';
+      assert std.isString(value) : '"id" expected to be of type "string"';
+
       {
-        id: converted,
+        id: value,
       }
     ),
+
     "#withPriority":: "Priority of group assignment",
     withPriority(value):: (
-      local converted = value;
-      assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+      assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
       {
-        priority: converted,
+        priority: value,
       }
     ),
+
     "#withProfile":: "JSON document containing [application profile](https://developer.okta.com/docs/reference/api/apps/#profile-object)",
     withProfile(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"profile" expected to be of type "string"';
+      assert std.isString(value) : '"profile" expected to be of type "string"';
+
       {
-        profile: converted,
+        profile: value,
       }
     ),
   },
   timeouts:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withCreate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"create" expected to be of type "string"';
+      assert std.isString(value) : '"create" expected to be of type "string"';
+
       {
-        create: converted,
+        create: value,
       }
     ),
+
     withRead(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"read" expected to be of type "string"';
+      assert std.isString(value) : '"read" expected to be of type "string"';
+
       {
-        read: converted,
+        read: value,
       }
     ),
+
     withUpdate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"update" expected to be of type "string"';
+      assert std.isString(value) : '"update" expected to be of type "string"';
+
       {
-        update: converted,
+        update: value,
       }
     ),
   },
   withGroup(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      group: value,
+      group: converted,
     }
   ),
   withTimeouts(value):: (
-    local converted = value;
     {
       timeouts: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_oauth.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_oauth.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, label, type):: (
     {
       jsonnetTfMetadata:: {
@@ -14,403 +15,463 @@
     + block.withLabel(label)
     + block.withType(type)
   ),
+
   "#withAccessibilityErrorRedirectUrl":: "Custom error page URL",
   withAccessibilityErrorRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_error_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_error_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_error_redirect_url: converted,
+      accessibility_error_redirect_url: value,
     }
   ),
+
   "#withAccessibilityLoginRedirectUrl":: "Custom login page URL",
   withAccessibilityLoginRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_login_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_login_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_login_redirect_url: converted,
+      accessibility_login_redirect_url: value,
     }
   ),
+
   "#withAccessibilitySelfService":: "Enable self service. Default is `false`",
   withAccessibilitySelfService(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"accessibility_self_service" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"accessibility_self_service" expected to be of type "bool"';
+
     {
-      accessibility_self_service: converted,
+      accessibility_self_service: value,
     }
   ),
+
   "#withAdminNote":: "Application notes for admins.",
   withAdminNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"admin_note" expected to be of type "string"';
+    assert std.isString(value) : '"admin_note" expected to be of type "string"';
+
     {
-      admin_note: converted,
+      admin_note: value,
     }
   ),
+
   "#withAppLinksJson":: "Displays specific appLinks for the app. The value for each application link should be boolean.",
   withAppLinksJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_links_json" expected to be of type "string"';
+    assert std.isString(value) : '"app_links_json" expected to be of type "string"';
+
     {
-      app_links_json: converted,
+      app_links_json: value,
     }
   ),
+
   "#withAppSettingsJson":: "Application settings in JSON format",
   withAppSettingsJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_settings_json" expected to be of type "string"';
+    assert std.isString(value) : '"app_settings_json" expected to be of type "string"';
+
     {
-      app_settings_json: converted,
+      app_settings_json: value,
     }
   ),
+
   "#withAuthenticationPolicy":: "The ID of the associated app_signon_policy. If this property is removed from the application, the default sign-on-policy will be associated with this application. From now on, there is no need to attach authentication_policy for applications of type SERVICE",
   withAuthenticationPolicy(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"authentication_policy" expected to be of type "string"';
+    assert std.isString(value) : '"authentication_policy" expected to be of type "string"';
+
     {
-      authentication_policy: converted,
+      authentication_policy: value,
     }
   ),
+
   "#withAutoKeyRotation":: "Requested key rotation mode. If \t\t\t\tauto_key_rotation isn't specified, the client automatically opts in for Okta's \t\t\t\tkey rotation. You can update this property via the API or via the administrator \t\t\t\tUI. \t\t\t\tSee: https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object'",
   withAutoKeyRotation(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"auto_key_rotation" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"auto_key_rotation" expected to be of type "bool"';
+
     {
-      auto_key_rotation: converted,
+      auto_key_rotation: value,
     }
   ),
+
   "#withAutoSubmitToolbar":: "Display auto submit toolbar",
   withAutoSubmitToolbar(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"auto_submit_toolbar" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"auto_submit_toolbar" expected to be of type "bool"';
+
     {
-      auto_submit_toolbar: converted,
+      auto_submit_toolbar: value,
     }
   ),
+
   "#withClientBasicSecret":: "The user provided OAuth client secret key value, this can be set when token_endpoint_auth_method is client_secret_basic. This does nothing when `omit_secret is set to true.",
   withClientBasicSecret(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"client_basic_secret" expected to be of type "string"';
+    assert std.isString(value) : '"client_basic_secret" expected to be of type "string"';
+
     {
-      client_basic_secret: converted,
+      client_basic_secret: value,
     }
   ),
+
   "#withClientId":: "OAuth client ID. If set during creation, app is created with this id.",
   withClientId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"client_id" expected to be of type "string"';
+    assert std.isString(value) : '"client_id" expected to be of type "string"';
+
     {
-      client_id: converted,
+      client_id: value,
     }
   ),
+
   "#withClientUri":: "URI to a web page providing information about the client.",
   withClientUri(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"client_uri" expected to be of type "string"';
+    assert std.isString(value) : '"client_uri" expected to be of type "string"';
+
     {
-      client_uri: converted,
+      client_uri: value,
     }
   ),
+
   "#withConsentMethod":: "*Early Access Property*. Indicates whether user consent is required or implicit. Valid values: REQUIRED, TRUSTED. Default value is TRUSTED",
   withConsentMethod(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"consent_method" expected to be of type "string"';
+    assert std.isString(value) : '"consent_method" expected to be of type "string"';
+
     {
-      consent_method: converted,
+      consent_method: value,
     }
   ),
+
   "#withEnduserNote":: "Application notes for end users.",
   withEnduserNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"enduser_note" expected to be of type "string"';
+    assert std.isString(value) : '"enduser_note" expected to be of type "string"';
+
     {
-      enduser_note: converted,
+      enduser_note: value,
     }
   ),
+
   "#withGrantTypes":: "List of OAuth 2.0 grant types. Conditional validation params found here https://developer.okta.com/docs/api/resources/apps#credentials-settings-details. Defaults to minimum requirements per app type.",
   withGrantTypes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"grant_types" expected to be of type "set"';
+
     {
       grant_types: converted,
     }
   ),
+
   "#withGrantTypesMixin":: "List of OAuth 2.0 grant types. Conditional validation params found here https://developer.okta.com/docs/api/resources/apps#credentials-settings-details. Defaults to minimum requirements per app type.",
   withGrantTypesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"grant_types" expected to be of type "set"';
+
     {
       grant_types+: converted,
     }
   ),
+
   "#withHideIos":: "Do not display application icon on mobile app",
   withHideIos(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_ios" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_ios" expected to be of type "bool"';
+
     {
-      hide_ios: converted,
+      hide_ios: value,
     }
   ),
+
   "#withHideWeb":: "Do not display application icon to users",
   withHideWeb(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_web" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_web" expected to be of type "bool"';
+
     {
-      hide_web: converted,
+      hide_web: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withImplicitAssignment":: "*Early Access Property*. Enable Federation Broker Mode.",
   withImplicitAssignment(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"implicit_assignment" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"implicit_assignment" expected to be of type "bool"';
+
     {
-      implicit_assignment: converted,
+      implicit_assignment: value,
     }
   ),
+
   "#withIssuerMode":: "*Early Access Property*. Indicates whether the Okta Authorization Server uses the original Okta org domain URL or a custom domain URL as the issuer of ID token for this client.",
   withIssuerMode(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"issuer_mode" expected to be of type "string"';
+    assert std.isString(value) : '"issuer_mode" expected to be of type "string"';
+
     {
-      issuer_mode: converted,
+      issuer_mode: value,
     }
   ),
+
   "#withJwksUri":: "URL reference to JWKS",
   withJwksUri(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"jwks_uri" expected to be of type "string"';
+    assert std.isString(value) : '"jwks_uri" expected to be of type "string"';
+
     {
-      jwks_uri: converted,
+      jwks_uri: value,
     }
   ),
+
   "#withLabel":: "The Application's display name.",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withLoginMode":: "The type of Idp-Initiated login that the client supports, if any",
   withLoginMode(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"login_mode" expected to be of type "string"';
+    assert std.isString(value) : '"login_mode" expected to be of type "string"';
+
     {
-      login_mode: converted,
+      login_mode: value,
     }
   ),
+
   "#withLoginScopes":: "List of scopes to use for the request",
   withLoginScopes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"login_scopes" expected to be of type "set"';
+
     {
       login_scopes: converted,
     }
   ),
+
   "#withLoginScopesMixin":: "List of scopes to use for the request",
   withLoginScopesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"login_scopes" expected to be of type "set"';
+
     {
       login_scopes+: converted,
     }
   ),
+
   "#withLoginUri":: "URI that initiates login.",
   withLoginUri(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"login_uri" expected to be of type "string"';
+    assert std.isString(value) : '"login_uri" expected to be of type "string"';
+
     {
-      login_uri: converted,
+      login_uri: value,
     }
   ),
+
   "#withLogo":: "Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.",
   withLogo(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"logo" expected to be of type "string"';
+    assert std.isString(value) : '"logo" expected to be of type "string"';
+
     {
-      logo: converted,
+      logo: value,
     }
   ),
+
   "#withLogoUri":: "URI that references a logo for the client.",
   withLogoUri(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"logo_uri" expected to be of type "string"';
+    assert std.isString(value) : '"logo_uri" expected to be of type "string"';
+
     {
-      logo_uri: converted,
+      logo_uri: value,
     }
   ),
+
   "#withOmitSecret":: "This tells the provider not manage the client_secret value in state. When this is false (the default), it will cause the auto-generated client_secret to be persisted in the client_secret attribute in state. This also means that every time an update to this app is run, this value is also set on the API. If this changes from false => true, the `client_secret` is dropped from state and the secret at the time of the apply is what remains. If this is ever changes from true => false your app will be recreated, due to the need to regenerate a secret we can store in state.",
   withOmitSecret(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"omit_secret" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"omit_secret" expected to be of type "bool"';
+
     {
-      omit_secret: converted,
+      omit_secret: value,
     }
   ),
+
   "#withPkceRequired":: "Require Proof Key for Code Exchange (PKCE) for additional verification key rotation mode. See: https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object",
   withPkceRequired(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"pkce_required" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"pkce_required" expected to be of type "bool"';
+
     {
-      pkce_required: converted,
+      pkce_required: value,
     }
   ),
+
   "#withPolicyUri":: "URI to web page providing client policy document.",
   withPolicyUri(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"policy_uri" expected to be of type "string"';
+    assert std.isString(value) : '"policy_uri" expected to be of type "string"';
+
     {
-      policy_uri: converted,
+      policy_uri: value,
     }
   ),
+
   "#withPostLogoutRedirectUris":: "List of URIs for redirection after logout. Note: see okta_app_oauth_post_logout_redirect_uri for appending to this list in a decentralized way.",
   withPostLogoutRedirectUris(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"post_logout_redirect_uris" expected to be of type "set"';
+
     {
       post_logout_redirect_uris: converted,
     }
   ),
+
   "#withPostLogoutRedirectUrisMixin":: "List of URIs for redirection after logout. Note: see okta_app_oauth_post_logout_redirect_uri for appending to this list in a decentralized way.",
   withPostLogoutRedirectUrisMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"post_logout_redirect_uris" expected to be of type "set"';
+
     {
       post_logout_redirect_uris+: converted,
     }
   ),
+
   "#withProfile":: "Custom JSON that represents an OAuth application's profile",
   withProfile(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"profile" expected to be of type "string"';
+    assert std.isString(value) : '"profile" expected to be of type "string"';
+
     {
-      profile: converted,
+      profile: value,
     }
   ),
+
   "#withRedirectUris":: "List of URIs for use in the redirect-based flow. This is required for all application types except service. Note: see okta_app_oauth_redirect_uri for appending to this list in a decentralized way.",
   withRedirectUris(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"redirect_uris" expected to be of type "list"';
+
     {
       redirect_uris: converted,
     }
   ),
+
   "#withRedirectUrisMixin":: "List of URIs for use in the redirect-based flow. This is required for all application types except service. Note: see okta_app_oauth_redirect_uri for appending to this list in a decentralized way.",
   withRedirectUrisMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"redirect_uris" expected to be of type "list"';
+
     {
       redirect_uris+: converted,
     }
   ),
+
   "#withRefreshTokenLeeway":: "*Early Access Property* Grace period for token rotation, required with grant types refresh_token",
   withRefreshTokenLeeway(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"refresh_token_leeway" expected to be of type "number"';
+    assert std.isNumber(value) : '"refresh_token_leeway" expected to be of type "number"';
+
     {
-      refresh_token_leeway: converted,
+      refresh_token_leeway: value,
     }
   ),
+
   "#withRefreshTokenRotation":: "*Early Access Property* Refresh token rotation behavior, required with grant types refresh_token",
   withRefreshTokenRotation(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"refresh_token_rotation" expected to be of type "string"';
+    assert std.isString(value) : '"refresh_token_rotation" expected to be of type "string"';
+
     {
-      refresh_token_rotation: converted,
+      refresh_token_rotation: value,
     }
   ),
+
   "#withResponseTypes":: "List of OAuth 2.0 response type strings. Valid values are any combination of: `code`, `token`, and `id_token`.",
   withResponseTypes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"response_types" expected to be of type "set"';
+
     {
       response_types: converted,
     }
   ),
+
   "#withResponseTypesMixin":: "List of OAuth 2.0 response type strings. Valid values are any combination of: `code`, `token`, and `id_token`.",
   withResponseTypesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"response_types" expected to be of type "set"';
+
     {
       response_types+: converted,
     }
   ),
+
   "#withStatus":: "Status of application. By default, it is `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withTokenEndpointAuthMethod":: "Requested authentication method for the token endpoint, valid values include:  'client_secret_basic', 'client_secret_post', 'client_secret_jwt', 'private_key_jwt', 'none', etc.",
   withTokenEndpointAuthMethod(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"token_endpoint_auth_method" expected to be of type "string"';
+    assert std.isString(value) : '"token_endpoint_auth_method" expected to be of type "string"';
+
     {
-      token_endpoint_auth_method: converted,
+      token_endpoint_auth_method: value,
     }
   ),
+
   "#withTosUri":: "URI to web page providing client tos (terms of service).",
   withTosUri(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tos_uri" expected to be of type "string"';
+    assert std.isString(value) : '"tos_uri" expected to be of type "string"';
+
     {
-      tos_uri: converted,
+      tos_uri: value,
     }
   ),
+
   "#withType":: "The type of client application.",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
+
   "#withUserNameTemplate":: "Username template. Default: `${source.login}`",
   withUserNameTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template" expected to be of type "string"';
+
     {
-      user_name_template: converted,
+      user_name_template: value,
     }
   ),
+
   "#withUserNameTemplatePushStatus":: "Push username on update. Valid values: `PUSH` and `DONT_PUSH`",
   withUserNameTemplatePushStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_push_status" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_push_status" expected to be of type "string"';
+
     {
-      user_name_template_push_status: converted,
+      user_name_template_push_status: value,
     }
   ),
+
   "#withUserNameTemplateSuffix":: "Username template suffix",
   withUserNameTemplateSuffix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_suffix" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_suffix" expected to be of type "string"';
+
     {
-      user_name_template_suffix: converted,
+      user_name_template_suffix: value,
     }
   ),
+
   "#withUserNameTemplateType":: "Username template type. Default: `BUILT_IN`",
   withUserNameTemplateType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_type" expected to be of type "string"';
+
     {
-      user_name_template_type: converted,
+      user_name_template_type: value,
     }
   ),
+
   "#withWildcardRedirect":: "*Early Access Property*. Indicates if the client is allowed to use wildcard matching of redirect_uris",
   withWildcardRedirect(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"wildcard_redirect" expected to be of type "string"';
+    assert std.isString(value) : '"wildcard_redirect" expected to be of type "string"';
+
     {
-      wildcard_redirect: converted,
+      wildcard_redirect: value,
     }
   ),
   withTerraformName(value):: {
@@ -420,144 +481,160 @@
       },
     },
   },
+
   groupsClaim:: {
     local block = self,
+
     new(name, type, value):: (
       {}
       + block.withName(name)
       + block.withType(type)
       + block.withValue(value)
     ),
+
     "#withFilterType":: "Groups claim filter. Can only be set if type is FILTER.",
     withFilterType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"filter_type" expected to be of type "string"';
+      assert std.isString(value) : '"filter_type" expected to be of type "string"';
+
       {
-        filter_type: converted,
+        filter_type: value,
       }
     ),
+
     "#withName":: "Name of the claim that will be used in the token.",
     withName(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"name" expected to be of type "string"';
+      assert std.isString(value) : '"name" expected to be of type "string"';
+
       {
-        name: converted,
+        name: value,
       }
     ),
+
     "#withType":: "Groups claim type.",
     withType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"type" expected to be of type "string"';
+      assert std.isString(value) : '"type" expected to be of type "string"';
+
       {
-        type: converted,
+        type: value,
       }
     ),
+
     "#withValue":: "Value of the claim. Can be an Okta Expression Language statement that evaluates at the time the token is minted.",
     withValue(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"value" expected to be of type "string"';
+      assert std.isString(value) : '"value" expected to be of type "string"';
+
       {
-        value: converted,
+        value: value,
       }
     ),
   },
   jwks:: {
     local block = self,
+
     new(kid, kty):: (
       {}
       + block.withKid(kid)
       + block.withKty(kty)
     ),
+
     "#withE":: "RSA Exponent",
     withE(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"e" expected to be of type "string"';
+      assert std.isString(value) : '"e" expected to be of type "string"';
+
       {
-        e: converted,
+        e: value,
       }
     ),
+
     "#withKid":: "Key ID",
     withKid(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"kid" expected to be of type "string"';
+      assert std.isString(value) : '"kid" expected to be of type "string"';
+
       {
-        kid: converted,
+        kid: value,
       }
     ),
+
     "#withKty":: "Key type",
     withKty(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"kty" expected to be of type "string"';
+      assert std.isString(value) : '"kty" expected to be of type "string"';
+
       {
-        kty: converted,
+        kty: value,
       }
     ),
+
     "#withN":: "RSA Modulus",
     withN(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"n" expected to be of type "string"';
+      assert std.isString(value) : '"n" expected to be of type "string"';
+
       {
-        n: converted,
+        n: value,
       }
     ),
+
     "#withX":: "X coordinate of the elliptic curve point",
     withX(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"x" expected to be of type "string"';
+      assert std.isString(value) : '"x" expected to be of type "string"';
+
       {
-        x: converted,
+        x: value,
       }
     ),
+
     "#withY":: "Y coordinate of the elliptic curve point",
     withY(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"y" expected to be of type "string"';
+      assert std.isString(value) : '"y" expected to be of type "string"';
+
       {
-        y: converted,
+        y: value,
       }
     ),
   },
   timeouts:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withCreate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"create" expected to be of type "string"';
+      assert std.isString(value) : '"create" expected to be of type "string"';
+
       {
-        create: converted,
+        create: value,
       }
     ),
+
     withRead(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"read" expected to be of type "string"';
+      assert std.isString(value) : '"read" expected to be of type "string"';
+
       {
-        read: converted,
+        read: value,
       }
     ),
+
     withUpdate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"update" expected to be of type "string"';
+      assert std.isString(value) : '"update" expected to be of type "string"';
+
       {
-        update: converted,
+        update: value,
       }
     ),
   },
   withGroupsClaim(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      groups_claim: value,
+      groups_claim: converted,
     }
   ),
   withJwks(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      jwks: value,
+      jwks: converted,
     }
   ),
   withTimeouts(value):: (
-    local converted = value;
     {
       timeouts: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_oauth_api_scope.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_oauth_api_scope.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, appId, issuer, scopes):: (
     {
       jsonnetTfMetadata:: {
@@ -15,41 +16,48 @@
     + block.withIssuer(issuer)
     + block.withScopes(scopes)
   ),
+
   "#withAppId":: "ID of the application.",
   withAppId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_id" expected to be of type "string"';
+    assert std.isString(value) : '"app_id" expected to be of type "string"';
+
     {
-      app_id: converted,
+      app_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIssuer":: "The issuer of your Org Authorization Server, your Org URL.",
   withIssuer(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"issuer" expected to be of type "string"';
+    assert std.isString(value) : '"issuer" expected to be of type "string"';
+
     {
-      issuer: converted,
+      issuer: value,
     }
   ),
+
   "#withScopes":: "Scopes of the application for which consent is granted.",
   withScopes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"scopes" expected to be of type "set"';
+
     {
       scopes: converted,
     }
   ),
+
   "#withScopesMixin":: "Scopes of the application for which consent is granted.",
   withScopesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"scopes" expected to be of type "set"';
+
     {
       scopes+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_oauth_post_logout_redirect_uri.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_oauth_post_logout_redirect_uri.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, appId, uri):: (
     {
       jsonnetTfMetadata:: {
@@ -14,27 +15,30 @@
     + block.withAppId(appId)
     + block.withUri(uri)
   ),
+
   "#withAppId":: "OAuth application ID.",
   withAppId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_id" expected to be of type "string"';
+    assert std.isString(value) : '"app_id" expected to be of type "string"';
+
     {
-      app_id: converted,
+      app_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withUri":: "Post Logout Redirect URI to append to Okta OIDC application.",
   withUri(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"uri" expected to be of type "string"';
+    assert std.isString(value) : '"uri" expected to be of type "string"';
+
     {
-      uri: converted,
+      uri: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_oauth_redirect_uri.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_oauth_redirect_uri.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, appId, uri):: (
     {
       jsonnetTfMetadata:: {
@@ -14,27 +15,30 @@
     + block.withAppId(appId)
     + block.withUri(uri)
   ),
+
   "#withAppId":: "OAuth application ID.",
   withAppId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_id" expected to be of type "string"';
+    assert std.isString(value) : '"app_id" expected to be of type "string"';
+
     {
-      app_id: converted,
+      app_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withUri":: "Redirect URI to append to Okta OIDC application.",
   withUri(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"uri" expected to be of type "string"';
+    assert std.isString(value) : '"uri" expected to be of type "string"';
+
     {
-      uri: converted,
+      uri: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_oauth_role_assignment.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_oauth_role_assignment.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, clientId, type):: (
     {
       jsonnetTfMetadata:: {
@@ -14,36 +15,40 @@
     + block.withClientId(clientId)
     + block.withType(type)
   ),
+
   "#withClientId":: "Client ID for the role to be assigned to",
   withClientId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"client_id" expected to be of type "string"';
+    assert std.isString(value) : '"client_id" expected to be of type "string"';
+
     {
-      client_id: converted,
+      client_id: value,
     }
   ),
+
   "#withResourceSet":: "Resource set for the custom role to assign, must be the ID of the created resource set.",
   withResourceSet(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"resource_set" expected to be of type "string"';
+    assert std.isString(value) : '"resource_set" expected to be of type "string"';
+
     {
-      resource_set: converted,
+      resource_set: value,
     }
   ),
+
   "#withRole":: "Custom Role ID",
   withRole(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"role" expected to be of type "string"';
+    assert std.isString(value) : '"role" expected to be of type "string"';
+
     {
-      role: converted,
+      role: value,
     }
   ),
+
   "#withType":: "Role type to assign. This can be one of the standard Okta roles, such as `HELP_DESK_ADMIN`, or `CUSTOM`. Using custom requires the `resource_set` and `role` attributes to be set.",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_saml.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_saml.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, label):: (
     {
       jsonnetTfMetadata:: {
@@ -13,379 +14,428 @@
     }
     + block.withLabel(label)
   ),
+
   "#withAccessibilityErrorRedirectUrl":: "Custom error page URL",
   withAccessibilityErrorRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_error_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_error_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_error_redirect_url: converted,
+      accessibility_error_redirect_url: value,
     }
   ),
+
   "#withAccessibilityLoginRedirectUrl":: "Custom login page URL",
   withAccessibilityLoginRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_login_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_login_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_login_redirect_url: converted,
+      accessibility_login_redirect_url: value,
     }
   ),
+
   "#withAccessibilitySelfService":: "Enable self service. Default is `false`",
   withAccessibilitySelfService(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"accessibility_self_service" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"accessibility_self_service" expected to be of type "bool"';
+
     {
-      accessibility_self_service: converted,
+      accessibility_self_service: value,
     }
   ),
+
   "#withAcsEndpoints":: "An array of ACS endpoints. You can configure a maximum of 100 endpoints.",
   withAcsEndpoints(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"acs_endpoints" expected to be of type "list"';
+
     {
       acs_endpoints: converted,
     }
   ),
+
   "#withAcsEndpointsMixin":: "An array of ACS endpoints. You can configure a maximum of 100 endpoints.",
   withAcsEndpointsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"acs_endpoints" expected to be of type "list"';
+
     {
       acs_endpoints+: converted,
     }
   ),
+
   "#withAdminNote":: "Application notes for admins.",
   withAdminNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"admin_note" expected to be of type "string"';
+    assert std.isString(value) : '"admin_note" expected to be of type "string"';
+
     {
-      admin_note: converted,
+      admin_note: value,
     }
   ),
+
   "#withAppLinksJson":: "Displays specific appLinks for the app. The value for each application link should be boolean.",
   withAppLinksJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_links_json" expected to be of type "string"';
+    assert std.isString(value) : '"app_links_json" expected to be of type "string"';
+
     {
-      app_links_json: converted,
+      app_links_json: value,
     }
   ),
+
   "#withAppSettingsJson":: "Application settings in JSON format",
   withAppSettingsJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_settings_json" expected to be of type "string"';
+    assert std.isString(value) : '"app_settings_json" expected to be of type "string"';
+
     {
-      app_settings_json: converted,
+      app_settings_json: value,
     }
   ),
+
   "#withAssertionSigned":: "Determines whether the SAML assertion is digitally signed",
   withAssertionSigned(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"assertion_signed" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"assertion_signed" expected to be of type "bool"';
+
     {
-      assertion_signed: converted,
+      assertion_signed: value,
     }
   ),
+
   "#withAudience":: "Audience Restriction",
   withAudience(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"audience" expected to be of type "string"';
+    assert std.isString(value) : '"audience" expected to be of type "string"';
+
     {
-      audience: converted,
+      audience: value,
     }
   ),
+
   "#withAuthenticationPolicy":: "The ID of the associated `app_signon_policy`. If this property is removed from the application the `default` sign-on-policy will be associated with this application.y",
   withAuthenticationPolicy(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"authentication_policy" expected to be of type "string"';
+    assert std.isString(value) : '"authentication_policy" expected to be of type "string"';
+
     {
-      authentication_policy: converted,
+      authentication_policy: value,
     }
   ),
+
   "#withAuthnContextClassRef":: "Identifies the SAML authentication context class for the assertion’s authentication statement",
   withAuthnContextClassRef(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"authn_context_class_ref" expected to be of type "string"';
+    assert std.isString(value) : '"authn_context_class_ref" expected to be of type "string"';
+
     {
-      authn_context_class_ref: converted,
+      authn_context_class_ref: value,
     }
   ),
+
   "#withAutoSubmitToolbar":: "Display auto submit toolbar. Default is: `false`",
   withAutoSubmitToolbar(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"auto_submit_toolbar" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"auto_submit_toolbar" expected to be of type "bool"';
+
     {
-      auto_submit_toolbar: converted,
+      auto_submit_toolbar: value,
     }
   ),
+
   "#withDefaultRelayState":: "Identifies a specific application resource in an IDP initiated SSO scenario.",
   withDefaultRelayState(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"default_relay_state" expected to be of type "string"';
+    assert std.isString(value) : '"default_relay_state" expected to be of type "string"';
+
     {
-      default_relay_state: converted,
+      default_relay_state: value,
     }
   ),
+
   "#withDestination":: "Identifies the location where the SAML response is intended to be sent inside of the SAML assertion",
   withDestination(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"destination" expected to be of type "string"';
+    assert std.isString(value) : '"destination" expected to be of type "string"';
+
     {
-      destination: converted,
+      destination: value,
     }
   ),
+
   "#withDigestAlgorithm":: "Determines the digest algorithm used to digitally sign the SAML assertion and response",
   withDigestAlgorithm(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"digest_algorithm" expected to be of type "string"';
+    assert std.isString(value) : '"digest_algorithm" expected to be of type "string"';
+
     {
-      digest_algorithm: converted,
+      digest_algorithm: value,
     }
   ),
+
   "#withEnduserNote":: "Application notes for end users.",
   withEnduserNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"enduser_note" expected to be of type "string"';
+    assert std.isString(value) : '"enduser_note" expected to be of type "string"';
+
     {
-      enduser_note: converted,
+      enduser_note: value,
     }
   ),
+
   "#withHideIos":: "Do not display application icon on mobile app",
   withHideIos(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_ios" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_ios" expected to be of type "bool"';
+
     {
-      hide_ios: converted,
+      hide_ios: value,
     }
   ),
+
   "#withHideWeb":: "Do not display application icon to users",
   withHideWeb(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_web" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_web" expected to be of type "bool"';
+
     {
-      hide_web: converted,
+      hide_web: value,
     }
   ),
+
   "#withHonorForceAuthn":: "Prompt user to re-authenticate if SP asks for it. Default is: `false`",
   withHonorForceAuthn(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"honor_force_authn" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"honor_force_authn" expected to be of type "bool"';
+
     {
-      honor_force_authn: converted,
+      honor_force_authn: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIdpIssuer":: "SAML issuer ID",
   withIdpIssuer(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"idp_issuer" expected to be of type "string"';
+    assert std.isString(value) : '"idp_issuer" expected to be of type "string"';
+
     {
-      idp_issuer: converted,
+      idp_issuer: value,
     }
   ),
+
   "#withImplicitAssignment":: "*Early Access Property*. Enable Federation Broker Mode.",
   withImplicitAssignment(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"implicit_assignment" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"implicit_assignment" expected to be of type "bool"';
+
     {
-      implicit_assignment: converted,
+      implicit_assignment: value,
     }
   ),
+
   "#withInlineHookId":: "Saml Inline Hook setting",
   withInlineHookId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"inline_hook_id" expected to be of type "string"';
+    assert std.isString(value) : '"inline_hook_id" expected to be of type "string"';
+
     {
-      inline_hook_id: converted,
+      inline_hook_id: value,
     }
   ),
+
   "#withKeyName":: "Certificate name. This modulates the rotation of keys. New name == new key. Required to be set with `key_years_valid`",
   withKeyName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"key_name" expected to be of type "string"';
+    assert std.isString(value) : '"key_name" expected to be of type "string"';
+
     {
-      key_name: converted,
+      key_name: value,
     }
   ),
+
   "#withKeyYearsValid":: "Number of years the certificate is valid (2 - 10 years).",
   withKeyYearsValid(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"key_years_valid" expected to be of type "number"';
+    assert std.isNumber(value) : '"key_years_valid" expected to be of type "number"';
+
     {
-      key_years_valid: converted,
+      key_years_valid: value,
     }
   ),
+
   "#withLabel":: "The Application's display name.",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withLogo":: "Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.",
   withLogo(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"logo" expected to be of type "string"';
+    assert std.isString(value) : '"logo" expected to be of type "string"';
+
     {
-      logo: converted,
+      logo: value,
     }
   ),
+
   "#withPreconfiguredApp":: "Name of application from the Okta Integration Network. For instance 'slack'. If not included a custom app will be created.  If not provided the following arguments are required: 'sso_url' 'recipient' 'destination' 'audience' 'subject_name_id_template' 'subject_name_id_format' 'signature_algorithm' 'digest_algorithm' 'authn_context_class_ref'",
   withPreconfiguredApp(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"preconfigured_app" expected to be of type "string"';
+    assert std.isString(value) : '"preconfigured_app" expected to be of type "string"';
+
     {
-      preconfigured_app: converted,
+      preconfigured_app: value,
     }
   ),
+
   "#withRecipient":: "The location where the app may present the SAML assertion",
   withRecipient(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"recipient" expected to be of type "string"';
+    assert std.isString(value) : '"recipient" expected to be of type "string"';
+
     {
-      recipient: converted,
+      recipient: value,
     }
   ),
+
   "#withRequestCompressed":: "Denotes whether the request is compressed or not.",
   withRequestCompressed(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"request_compressed" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"request_compressed" expected to be of type "bool"';
+
     {
-      request_compressed: converted,
+      request_compressed: value,
     }
   ),
+
   "#withResponseSigned":: "Determines whether the SAML auth response message is digitally signed",
   withResponseSigned(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"response_signed" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"response_signed" expected to be of type "bool"';
+
     {
-      response_signed: converted,
+      response_signed: value,
     }
   ),
+
   "#withSamlSignedRequestEnabled":: "SAML Signed Request enabled",
   withSamlSignedRequestEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"saml_signed_request_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"saml_signed_request_enabled" expected to be of type "bool"';
+
     {
-      saml_signed_request_enabled: converted,
+      saml_signed_request_enabled: value,
     }
   ),
+
   "#withSamlVersion":: "SAML version for the app's sign-on mode. Valid values are: `2.0` or `1.1`. Default is `2.0`",
   withSamlVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"saml_version" expected to be of type "string"';
+    assert std.isString(value) : '"saml_version" expected to be of type "string"';
+
     {
-      saml_version: converted,
+      saml_version: value,
     }
   ),
+
   "#withSignatureAlgorithm":: "Signature algorithm used to digitally sign the assertion and response",
   withSignatureAlgorithm(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"signature_algorithm" expected to be of type "string"';
+    assert std.isString(value) : '"signature_algorithm" expected to be of type "string"';
+
     {
-      signature_algorithm: converted,
+      signature_algorithm: value,
     }
   ),
+
   "#withSingleLogoutCertificate":: "x509 encoded certificate that the Service Provider uses to sign Single Logout requests. Note: should be provided without `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`, see [official documentation](https://developer.okta.com/docs/reference/api/apps/#service-provider-certificate).",
   withSingleLogoutCertificate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"single_logout_certificate" expected to be of type "string"';
+    assert std.isString(value) : '"single_logout_certificate" expected to be of type "string"';
+
     {
-      single_logout_certificate: converted,
+      single_logout_certificate: value,
     }
   ),
+
   "#withSingleLogoutIssuer":: "The issuer of the Service Provider that generates the Single Logout request",
   withSingleLogoutIssuer(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"single_logout_issuer" expected to be of type "string"';
+    assert std.isString(value) : '"single_logout_issuer" expected to be of type "string"';
+
     {
-      single_logout_issuer: converted,
+      single_logout_issuer: value,
     }
   ),
+
   "#withSingleLogoutUrl":: "The location where the logout response is sent",
   withSingleLogoutUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"single_logout_url" expected to be of type "string"';
+    assert std.isString(value) : '"single_logout_url" expected to be of type "string"';
+
     {
-      single_logout_url: converted,
+      single_logout_url: value,
     }
   ),
+
   "#withSpIssuer":: "SAML SP issuer ID",
   withSpIssuer(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"sp_issuer" expected to be of type "string"';
+    assert std.isString(value) : '"sp_issuer" expected to be of type "string"';
+
     {
-      sp_issuer: converted,
+      sp_issuer: value,
     }
   ),
+
   "#withSsoUrl":: "Single Sign On URL",
   withSsoUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"sso_url" expected to be of type "string"';
+    assert std.isString(value) : '"sso_url" expected to be of type "string"';
+
     {
-      sso_url: converted,
+      sso_url: value,
     }
   ),
+
   "#withStatus":: "Status of application. By default, it is `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withSubjectNameIdFormat":: "Identifies the SAML processing rules.",
   withSubjectNameIdFormat(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"subject_name_id_format" expected to be of type "string"';
+    assert std.isString(value) : '"subject_name_id_format" expected to be of type "string"';
+
     {
-      subject_name_id_format: converted,
+      subject_name_id_format: value,
     }
   ),
+
   "#withSubjectNameIdTemplate":: "Template for app user's username when a user is assigned to the app",
   withSubjectNameIdTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"subject_name_id_template" expected to be of type "string"';
+    assert std.isString(value) : '"subject_name_id_template" expected to be of type "string"';
+
     {
-      subject_name_id_template: converted,
+      subject_name_id_template: value,
     }
   ),
+
   "#withUserNameTemplate":: "Username template. Default: `${source.login}`",
   withUserNameTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template" expected to be of type "string"';
+
     {
-      user_name_template: converted,
+      user_name_template: value,
     }
   ),
+
   "#withUserNameTemplatePushStatus":: "Push username on update. Valid values: `PUSH` and `DONT_PUSH`",
   withUserNameTemplatePushStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_push_status" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_push_status" expected to be of type "string"';
+
     {
-      user_name_template_push_status: converted,
+      user_name_template_push_status: value,
     }
   ),
+
   "#withUserNameTemplateSuffix":: "Username template suffix",
   withUserNameTemplateSuffix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_suffix" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_suffix" expected to be of type "string"';
+
     {
-      user_name_template_suffix: converted,
+      user_name_template_suffix: value,
     }
   ),
+
   "#withUserNameTemplateType":: "Username template type. Default: `BUILT_IN`",
   withUserNameTemplateType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_type" expected to be of type "string"';
+
     {
-      user_name_template_type: converted,
+      user_name_template_type: value,
     }
   ),
   withTerraformName(value):: {
@@ -395,84 +445,98 @@
       },
     },
   },
+
   acsEndpointsIndices:: {
     local block = self,
+
     new(index, url):: (
       {}
       + block.withIndex(index)
       + block.withUrl(url)
     ),
+
     withIndex(value):: (
-      local converted = value;
-      assert std.isNumber(converted) : '"index" expected to be of type "number"';
+      assert std.isNumber(value) : '"index" expected to be of type "number"';
+
       {
-        index: converted,
+        index: value,
       }
     ),
+
     withUrl(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"url" expected to be of type "string"';
+      assert std.isString(value) : '"url" expected to be of type "string"';
+
       {
-        url: converted,
+        url: value,
       }
     ),
   },
   attributeStatements:: {
     local block = self,
+
     new(name):: (
       {}
       + block.withName(name)
     ),
+
     "#withFilterType":: "Type of group attribute filter. Valid values are: `STARTS_WITH`, `EQUALS`, `CONTAINS`, or `REGEX`",
     withFilterType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"filter_type" expected to be of type "string"';
+      assert std.isString(value) : '"filter_type" expected to be of type "string"';
+
       {
-        filter_type: converted,
+        filter_type: value,
       }
     ),
+
     "#withFilterValue":: "Filter value to use",
     withFilterValue(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"filter_value" expected to be of type "string"';
+      assert std.isString(value) : '"filter_value" expected to be of type "string"';
+
       {
-        filter_value: converted,
+        filter_value: value,
       }
     ),
+
     "#withName":: "The reference name of the attribute statement",
     withName(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"name" expected to be of type "string"';
+      assert std.isString(value) : '"name" expected to be of type "string"';
+
       {
-        name: converted,
+        name: value,
       }
     ),
+
     "#withNamespace":: "The attribute namespace. It can be set to `urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified`, `urn:oasis:names:tc:SAML:2.0:attrname-format:uri`, or `urn:oasis:names:tc:SAML:2.0:attrname-format:basic`",
     withNamespace(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"namespace" expected to be of type "string"';
+      assert std.isString(value) : '"namespace" expected to be of type "string"';
+
       {
-        namespace: converted,
+        namespace: value,
       }
     ),
+
     "#withType":: "The type of attribute statements object",
     withType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"type" expected to be of type "string"';
+      assert std.isString(value) : '"type" expected to be of type "string"';
+
       {
-        type: converted,
+        type: value,
       }
     ),
+
     withValues(value):: (
       local converted = if std.isArray(value) then value else [value];
       assert std.isArray(converted) : '"values" expected to be of type "list"';
+
       {
         values: converted,
       }
     ),
+
     withValuesMixin(value):: (
       local converted = if std.isArray(value) then value else [value];
       assert std.isArray(converted) : '"values" expected to be of type "list"';
+
       {
         values+: converted,
       }
@@ -480,45 +544,48 @@
   },
   timeouts:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withCreate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"create" expected to be of type "string"';
+      assert std.isString(value) : '"create" expected to be of type "string"';
+
       {
-        create: converted,
+        create: value,
       }
     ),
+
     withRead(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"read" expected to be of type "string"';
+      assert std.isString(value) : '"read" expected to be of type "string"';
+
       {
-        read: converted,
+        read: value,
       }
     ),
+
     withUpdate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"update" expected to be of type "string"';
+      assert std.isString(value) : '"update" expected to be of type "string"';
+
       {
-        update: converted,
+        update: value,
       }
     ),
   },
   withAcsEndpointsIndices(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      acs_endpoints_indices: value,
+      acs_endpoints_indices: converted,
     }
   ),
   withAttributeStatements(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      attribute_statements: value,
+      attribute_statements: converted,
     }
   ),
   withTimeouts(value):: (
-    local converted = value;
     {
       timeouts: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_saml_app_settings.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_saml_app_settings.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, appId, settings):: (
     {
       jsonnetTfMetadata:: {
@@ -14,27 +15,30 @@
     + block.withAppId(appId)
     + block.withSettings(settings)
   ),
+
   "#withAppId":: "ID of the application.",
   withAppId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_id" expected to be of type "string"';
+    assert std.isString(value) : '"app_id" expected to be of type "string"';
+
     {
-      app_id: converted,
+      app_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withSettings":: "Application settings in JSON format",
   withSettings(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"settings" expected to be of type "string"';
+    assert std.isString(value) : '"settings" expected to be of type "string"';
+
     {
-      settings: converted,
+      settings: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_secure_password_store.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_secure_password_store.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, label, passwordField, url, usernameField):: (
     {
       jsonnetTfMetadata:: {
@@ -16,243 +17,273 @@
     + block.withUrl(url)
     + block.withUsernameField(usernameField)
   ),
+
   "#withAccessibilityErrorRedirectUrl":: "Custom error page URL",
   withAccessibilityErrorRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_error_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_error_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_error_redirect_url: converted,
+      accessibility_error_redirect_url: value,
     }
   ),
+
   "#withAccessibilityLoginRedirectUrl":: "Custom login page URL",
   withAccessibilityLoginRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_login_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_login_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_login_redirect_url: converted,
+      accessibility_login_redirect_url: value,
     }
   ),
+
   "#withAccessibilitySelfService":: "Enable self service. Default is `false`",
   withAccessibilitySelfService(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"accessibility_self_service" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"accessibility_self_service" expected to be of type "bool"';
+
     {
-      accessibility_self_service: converted,
+      accessibility_self_service: value,
     }
   ),
+
   "#withAdminNote":: "Application notes for admins.",
   withAdminNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"admin_note" expected to be of type "string"';
+    assert std.isString(value) : '"admin_note" expected to be of type "string"';
+
     {
-      admin_note: converted,
+      admin_note: value,
     }
   ),
+
   "#withAppLinksJson":: "Displays specific appLinks for the app. The value for each application link should be boolean.",
   withAppLinksJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_links_json" expected to be of type "string"';
+    assert std.isString(value) : '"app_links_json" expected to be of type "string"';
+
     {
-      app_links_json: converted,
+      app_links_json: value,
     }
   ),
+
   "#withAutoSubmitToolbar":: "Display auto submit toolbar",
   withAutoSubmitToolbar(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"auto_submit_toolbar" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"auto_submit_toolbar" expected to be of type "bool"';
+
     {
-      auto_submit_toolbar: converted,
+      auto_submit_toolbar: value,
     }
   ),
+
   "#withCredentialsScheme":: "Application credentials scheme. One of: `EDIT_USERNAME_AND_PASSWORD`, `ADMIN_SETS_CREDENTIALS`, `EDIT_PASSWORD_ONLY`, `EXTERNAL_PASSWORD_SYNC`, or `SHARED_USERNAME_AND_PASSWORD`",
   withCredentialsScheme(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"credentials_scheme" expected to be of type "string"';
+    assert std.isString(value) : '"credentials_scheme" expected to be of type "string"';
+
     {
-      credentials_scheme: converted,
+      credentials_scheme: value,
     }
   ),
+
   "#withEnduserNote":: "Application notes for end users.",
   withEnduserNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"enduser_note" expected to be of type "string"';
+    assert std.isString(value) : '"enduser_note" expected to be of type "string"';
+
     {
-      enduser_note: converted,
+      enduser_note: value,
     }
   ),
+
   "#withHideIos":: "Do not display application icon on mobile app",
   withHideIos(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_ios" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_ios" expected to be of type "bool"';
+
     {
-      hide_ios: converted,
+      hide_ios: value,
     }
   ),
+
   "#withHideWeb":: "Do not display application icon to users",
   withHideWeb(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_web" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_web" expected to be of type "bool"';
+
     {
-      hide_web: converted,
+      hide_web: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLabel":: "The Application's display name.",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withLogo":: "Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.",
   withLogo(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"logo" expected to be of type "string"';
+    assert std.isString(value) : '"logo" expected to be of type "string"';
+
     {
-      logo: converted,
+      logo: value,
     }
   ),
+
   "#withOptionalField1":: "Name of optional param in the login form",
   withOptionalField1(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"optional_field1" expected to be of type "string"';
+    assert std.isString(value) : '"optional_field1" expected to be of type "string"';
+
     {
-      optional_field1: converted,
+      optional_field1: value,
     }
   ),
+
   "#withOptionalField1Value":: "Name of optional value in login form",
   withOptionalField1Value(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"optional_field1_value" expected to be of type "string"';
+    assert std.isString(value) : '"optional_field1_value" expected to be of type "string"';
+
     {
-      optional_field1_value: converted,
+      optional_field1_value: value,
     }
   ),
+
   "#withOptionalField2":: "Name of optional param in the login form",
   withOptionalField2(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"optional_field2" expected to be of type "string"';
+    assert std.isString(value) : '"optional_field2" expected to be of type "string"';
+
     {
-      optional_field2: converted,
+      optional_field2: value,
     }
   ),
+
   "#withOptionalField2Value":: "Name of optional value in login form",
   withOptionalField2Value(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"optional_field2_value" expected to be of type "string"';
+    assert std.isString(value) : '"optional_field2_value" expected to be of type "string"';
+
     {
-      optional_field2_value: converted,
+      optional_field2_value: value,
     }
   ),
+
   "#withOptionalField3":: "Name of optional param in the login form",
   withOptionalField3(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"optional_field3" expected to be of type "string"';
+    assert std.isString(value) : '"optional_field3" expected to be of type "string"';
+
     {
-      optional_field3: converted,
+      optional_field3: value,
     }
   ),
+
   "#withOptionalField3Value":: "Name of optional value in login form",
   withOptionalField3Value(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"optional_field3_value" expected to be of type "string"';
+    assert std.isString(value) : '"optional_field3_value" expected to be of type "string"';
+
     {
-      optional_field3_value: converted,
+      optional_field3_value: value,
     }
   ),
+
   "#withPasswordField":: "Login password field",
   withPasswordField(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"password_field" expected to be of type "string"';
+    assert std.isString(value) : '"password_field" expected to be of type "string"';
+
     {
-      password_field: converted,
+      password_field: value,
     }
   ),
+
   "#withRevealPassword":: "Allow user to reveal password. It can not be set to `true` if `credentials_scheme` is `ADMIN_SETS_CREDENTIALS`, `SHARED_USERNAME_AND_PASSWORD` or `EXTERNAL_PASSWORD_SYNC`.",
   withRevealPassword(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"reveal_password" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"reveal_password" expected to be of type "bool"';
+
     {
-      reveal_password: converted,
+      reveal_password: value,
     }
   ),
+
   "#withSharedPassword":: "Shared password, required for certain schemes.",
   withSharedPassword(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"shared_password" expected to be of type "string"';
+    assert std.isString(value) : '"shared_password" expected to be of type "string"';
+
     {
-      shared_password: converted,
+      shared_password: value,
     }
   ),
+
   "#withSharedUsername":: "Shared username, required for certain schemes.",
   withSharedUsername(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"shared_username" expected to be of type "string"';
+    assert std.isString(value) : '"shared_username" expected to be of type "string"';
+
     {
-      shared_username: converted,
+      shared_username: value,
     }
   ),
+
   "#withStatus":: "Status of application. By default, it is `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withUrl":: "Login URL",
   withUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"url" expected to be of type "string"';
+    assert std.isString(value) : '"url" expected to be of type "string"';
+
     {
-      url: converted,
+      url: value,
     }
   ),
+
   "#withUserNameTemplate":: "Username template. Default: `${source.login}`",
   withUserNameTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template" expected to be of type "string"';
+
     {
-      user_name_template: converted,
+      user_name_template: value,
     }
   ),
+
   "#withUserNameTemplatePushStatus":: "Push username on update. Valid values: `PUSH` and `DONT_PUSH`",
   withUserNameTemplatePushStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_push_status" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_push_status" expected to be of type "string"';
+
     {
-      user_name_template_push_status: converted,
+      user_name_template_push_status: value,
     }
   ),
+
   "#withUserNameTemplateSuffix":: "Username template suffix",
   withUserNameTemplateSuffix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_suffix" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_suffix" expected to be of type "string"';
+
     {
-      user_name_template_suffix: converted,
+      user_name_template_suffix: value,
     }
   ),
+
   "#withUserNameTemplateType":: "Username template type. Default: `BUILT_IN`",
   withUserNameTemplateType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_type" expected to be of type "string"';
+
     {
-      user_name_template_type: converted,
+      user_name_template_type: value,
     }
   ),
+
   "#withUsernameField":: "Login username field",
   withUsernameField(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"username_field" expected to be of type "string"';
+    assert std.isString(value) : '"username_field" expected to be of type "string"';
+
     {
-      username_field: converted,
+      username_field: value,
     }
   ),
   withTerraformName(value):: {
@@ -262,35 +293,39 @@
       },
     },
   },
+
   timeouts:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withCreate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"create" expected to be of type "string"';
+      assert std.isString(value) : '"create" expected to be of type "string"';
+
       {
-        create: converted,
+        create: value,
       }
     ),
+
     withRead(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"read" expected to be of type "string"';
+      assert std.isString(value) : '"read" expected to be of type "string"';
+
       {
-        read: converted,
+        read: value,
       }
     ),
+
     withUpdate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"update" expected to be of type "string"';
+      assert std.isString(value) : '"update" expected to be of type "string"';
+
       {
-        update: converted,
+        update: value,
       }
     ),
   },
   withTimeouts(value):: (
-    local converted = value;
     {
       timeouts: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_shared_credentials.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_shared_credentials.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, label):: (
     {
       jsonnetTfMetadata:: {
@@ -13,219 +14,246 @@
     }
     + block.withLabel(label)
   ),
+
   "#withAccessibilityErrorRedirectUrl":: "Custom error page URL",
   withAccessibilityErrorRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_error_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_error_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_error_redirect_url: converted,
+      accessibility_error_redirect_url: value,
     }
   ),
+
   "#withAccessibilityLoginRedirectUrl":: "Custom login page URL",
   withAccessibilityLoginRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_login_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_login_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_login_redirect_url: converted,
+      accessibility_login_redirect_url: value,
     }
   ),
+
   "#withAccessibilitySelfService":: "Enable self service. Default is `false`",
   withAccessibilitySelfService(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"accessibility_self_service" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"accessibility_self_service" expected to be of type "bool"';
+
     {
-      accessibility_self_service: converted,
+      accessibility_self_service: value,
     }
   ),
+
   "#withAdminNote":: "Application notes for admins.",
   withAdminNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"admin_note" expected to be of type "string"';
+    assert std.isString(value) : '"admin_note" expected to be of type "string"';
+
     {
-      admin_note: converted,
+      admin_note: value,
     }
   ),
+
   "#withAppLinksJson":: "Displays specific appLinks for the app. The value for each application link should be boolean.",
   withAppLinksJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_links_json" expected to be of type "string"';
+    assert std.isString(value) : '"app_links_json" expected to be of type "string"';
+
     {
-      app_links_json: converted,
+      app_links_json: value,
     }
   ),
+
   "#withAutoSubmitToolbar":: "Display auto submit toolbar",
   withAutoSubmitToolbar(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"auto_submit_toolbar" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"auto_submit_toolbar" expected to be of type "bool"';
+
     {
-      auto_submit_toolbar: converted,
+      auto_submit_toolbar: value,
     }
   ),
+
   "#withButtonField":: "Login button field",
   withButtonField(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"button_field" expected to be of type "string"';
+    assert std.isString(value) : '"button_field" expected to be of type "string"';
+
     {
-      button_field: converted,
+      button_field: value,
     }
   ),
+
   "#withCheckbox":: "CSS selector for the checkbox",
   withCheckbox(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"checkbox" expected to be of type "string"';
+    assert std.isString(value) : '"checkbox" expected to be of type "string"';
+
     {
-      checkbox: converted,
+      checkbox: value,
     }
   ),
+
   "#withEnduserNote":: "Application notes for end users.",
   withEnduserNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"enduser_note" expected to be of type "string"';
+    assert std.isString(value) : '"enduser_note" expected to be of type "string"';
+
     {
-      enduser_note: converted,
+      enduser_note: value,
     }
   ),
+
   "#withHideIos":: "Do not display application icon on mobile app",
   withHideIos(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_ios" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_ios" expected to be of type "bool"';
+
     {
-      hide_ios: converted,
+      hide_ios: value,
     }
   ),
+
   "#withHideWeb":: "Do not display application icon to users",
   withHideWeb(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_web" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_web" expected to be of type "bool"';
+
     {
-      hide_web: converted,
+      hide_web: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLabel":: "The Application's display name.",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withLogo":: "Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.",
   withLogo(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"logo" expected to be of type "string"';
+    assert std.isString(value) : '"logo" expected to be of type "string"';
+
     {
-      logo: converted,
+      logo: value,
     }
   ),
+
   "#withPasswordField":: "Login password field",
   withPasswordField(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"password_field" expected to be of type "string"';
+    assert std.isString(value) : '"password_field" expected to be of type "string"';
+
     {
-      password_field: converted,
+      password_field: value,
     }
   ),
+
   "#withPreconfiguredApp":: "Name of application from the Okta Integration Network, if not included a custom app will be created.",
   withPreconfiguredApp(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"preconfigured_app" expected to be of type "string"';
+    assert std.isString(value) : '"preconfigured_app" expected to be of type "string"';
+
     {
-      preconfigured_app: converted,
+      preconfigured_app: value,
     }
   ),
+
   "#withRedirectUrl":: "Secondary URL of the sign-in page for this app",
   withRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"redirect_url" expected to be of type "string"';
+
     {
-      redirect_url: converted,
+      redirect_url: value,
     }
   ),
+
   "#withSharedPassword":: "Shared password, required for certain schemes.",
   withSharedPassword(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"shared_password" expected to be of type "string"';
+    assert std.isString(value) : '"shared_password" expected to be of type "string"';
+
     {
-      shared_password: converted,
+      shared_password: value,
     }
   ),
+
   "#withSharedUsername":: "Shared username, required for certain schemes.",
   withSharedUsername(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"shared_username" expected to be of type "string"';
+    assert std.isString(value) : '"shared_username" expected to be of type "string"';
+
     {
-      shared_username: converted,
+      shared_username: value,
     }
   ),
+
   "#withStatus":: "Status of application. By default, it is `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withUrl":: "The URL of the sign-in page for this app.",
   withUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"url" expected to be of type "string"';
+    assert std.isString(value) : '"url" expected to be of type "string"';
+
     {
-      url: converted,
+      url: value,
     }
   ),
+
   "#withUrlRegex":: "A regular expression that further restricts url to the specified regular expression.",
   withUrlRegex(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"url_regex" expected to be of type "string"';
+    assert std.isString(value) : '"url_regex" expected to be of type "string"';
+
     {
-      url_regex: converted,
+      url_regex: value,
     }
   ),
+
   "#withUserNameTemplate":: "Username template. Default: `${source.login}`",
   withUserNameTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template" expected to be of type "string"';
+
     {
-      user_name_template: converted,
+      user_name_template: value,
     }
   ),
+
   "#withUserNameTemplatePushStatus":: "Push username on update. Valid values: `PUSH` and `DONT_PUSH`",
   withUserNameTemplatePushStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_push_status" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_push_status" expected to be of type "string"';
+
     {
-      user_name_template_push_status: converted,
+      user_name_template_push_status: value,
     }
   ),
+
   "#withUserNameTemplateSuffix":: "Username template suffix",
   withUserNameTemplateSuffix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_suffix" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_suffix" expected to be of type "string"';
+
     {
-      user_name_template_suffix: converted,
+      user_name_template_suffix: value,
     }
   ),
+
   "#withUserNameTemplateType":: "Username template type. Default: `BUILT_IN`",
   withUserNameTemplateType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_type" expected to be of type "string"';
+
     {
-      user_name_template_type: converted,
+      user_name_template_type: value,
     }
   ),
+
   "#withUsernameField":: "Login username field",
   withUsernameField(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"username_field" expected to be of type "string"';
+    assert std.isString(value) : '"username_field" expected to be of type "string"';
+
     {
-      username_field: converted,
+      username_field: value,
     }
   ),
   withTerraformName(value):: {
@@ -235,35 +263,39 @@
       },
     },
   },
+
   timeouts:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withCreate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"create" expected to be of type "string"';
+      assert std.isString(value) : '"create" expected to be of type "string"';
+
       {
-        create: converted,
+        create: value,
       }
     ),
+
     withRead(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"read" expected to be of type "string"';
+      assert std.isString(value) : '"read" expected to be of type "string"';
+
       {
-        read: converted,
+        read: value,
       }
     ),
+
     withUpdate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"update" expected to be of type "string"';
+      assert std.isString(value) : '"update" expected to be of type "string"';
+
       {
-        update: converted,
+        update: value,
       }
     ),
   },
   withTimeouts(value):: (
-    local converted = value;
     {
       timeouts: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_signon_policy.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_signon_policy.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, description, name):: (
     {
       jsonnetTfMetadata:: {
@@ -14,36 +15,40 @@
     + block.withDescription(description)
     + block.withName(name)
   ),
+
   "#withCatchAll":: "If false, the default rule of the policy is set access to `DENY`. Otherwise default behavior of the default rule is to leave access at `ALLOW`.  **WARNING** setting this attribute to false changes policy rule's default behavior. Use at your own risk. This is only applied during creation and does not affect import or update.",
   withCatchAll(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"catch_all" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"catch_all" expected to be of type "bool"';
+
     {
-      catch_all: converted,
+      catch_all: value,
     }
   ),
+
   "#withDescription":: "Description of the policy.",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   "#withName":: "Name of the policy.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withPriority":: "Priority of the policy",
   withPriority(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+    assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
     {
-      priority: converted,
+      priority: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_signon_policy_rule.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_signon_policy_rule.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name, policyId):: (
     {
       jsonnetTfMetadata:: {
@@ -14,297 +15,356 @@
     + block.withName(name)
     + block.withPolicyId(policyId)
   ),
+
   "#withAccess":: "Allow or deny access based on the rule conditions: ALLOW or DENY",
   withAccess(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"access" expected to be of type "string"';
+    assert std.isString(value) : '"access" expected to be of type "string"';
+
     {
-      access: converted,
+      access: value,
     }
   ),
+
   "#withChains":: "Use with verification method = `AUTH_METHOD_CHAIN` only",
   withChains(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"chains" expected to be of type "list"';
+
     {
       chains: converted,
     }
   ),
+
   "#withChainsMixin":: "Use with verification method = `AUTH_METHOD_CHAIN` only",
   withChainsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"chains" expected to be of type "list"';
+
     {
       chains+: converted,
     }
   ),
+
   "#withConstraints":: "An array that contains nested Authenticator Constraint objects that are organized by the Authenticator class",
   withConstraints(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"constraints" expected to be of type "list"';
+
     {
       constraints: converted,
     }
   ),
+
   "#withConstraintsMixin":: "An array that contains nested Authenticator Constraint objects that are organized by the Authenticator class",
   withConstraintsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"constraints" expected to be of type "list"';
+
     {
       constraints+: converted,
     }
   ),
+
   "#withCustomExpression":: "This is an optional advanced setting. If the expression is formatted incorrectly or conflicts with conditions set above, the rule may not match any users.",
   withCustomExpression(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"custom_expression" expected to be of type "string"';
+    assert std.isString(value) : '"custom_expression" expected to be of type "string"';
+
     {
-      custom_expression: converted,
+      custom_expression: value,
     }
   ),
+
   "#withDeviceAssurancesIncluded":: "List of device assurance IDs to include",
   withDeviceAssurancesIncluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"device_assurances_included" expected to be of type "set"';
+
     {
       device_assurances_included: converted,
     }
   ),
+
   "#withDeviceAssurancesIncludedMixin":: "List of device assurance IDs to include",
   withDeviceAssurancesIncludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"device_assurances_included" expected to be of type "set"';
+
     {
       device_assurances_included+: converted,
     }
   ),
+
   "#withDeviceIsManaged":: "If the device is managed. A device is managed if it's managed by a device management system. When managed is passed, registered must also be included and must be set to true.",
   withDeviceIsManaged(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"device_is_managed" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"device_is_managed" expected to be of type "bool"';
+
     {
-      device_is_managed: converted,
+      device_is_managed: value,
     }
   ),
+
   "#withDeviceIsRegistered":: "If the device is registered. A device is registered if the User enrolls with Okta Verify that is installed on the device.",
   withDeviceIsRegistered(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"device_is_registered" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"device_is_registered" expected to be of type "bool"';
+
     {
-      device_is_registered: converted,
+      device_is_registered: value,
     }
   ),
+
   "#withFactorMode":: "The number of factors required to satisfy this assurance level",
   withFactorMode(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"factor_mode" expected to be of type "string"';
+    assert std.isString(value) : '"factor_mode" expected to be of type "string"';
+
     {
-      factor_mode: converted,
+      factor_mode: value,
     }
   ),
+
   "#withGroupsExcluded":: "List of group IDs to exclude",
   withGroupsExcluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_excluded" expected to be of type "set"';
+
     {
       groups_excluded: converted,
     }
   ),
+
   "#withGroupsExcludedMixin":: "List of group IDs to exclude",
   withGroupsExcludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_excluded" expected to be of type "set"';
+
     {
       groups_excluded+: converted,
     }
   ),
+
   "#withGroupsIncluded":: "List of group IDs to include",
   withGroupsIncluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_included" expected to be of type "set"';
+
     {
       groups_included: converted,
     }
   ),
+
   "#withGroupsIncludedMixin":: "List of group IDs to include",
   withGroupsIncludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_included" expected to be of type "set"';
+
     {
       groups_included+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withInactivityPeriod":: "The inactivity duration after which the end user must re-authenticate. Use the ISO 8601 Period format for recurring time intervals.",
   withInactivityPeriod(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"inactivity_period" expected to be of type "string"';
+    assert std.isString(value) : '"inactivity_period" expected to be of type "string"';
+
     {
-      inactivity_period: converted,
+      inactivity_period: value,
     }
   ),
+
   "#withName":: "Policy Rule Name",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withNetworkConnection":: "Network selection mode: ANYWHERE, ZONE, ON_NETWORK, or OFF_NETWORK.",
   withNetworkConnection(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"network_connection" expected to be of type "string"';
+    assert std.isString(value) : '"network_connection" expected to be of type "string"';
+
     {
-      network_connection: converted,
+      network_connection: value,
     }
   ),
+
   "#withNetworkExcludes":: "The zones to exclude",
   withNetworkExcludes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_excludes" expected to be of type "list"';
+
     {
       network_excludes: converted,
     }
   ),
+
   "#withNetworkExcludesMixin":: "The zones to exclude",
   withNetworkExcludesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_excludes" expected to be of type "list"';
+
     {
       network_excludes+: converted,
     }
   ),
+
   "#withNetworkIncludes":: "The zones to include",
   withNetworkIncludes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_includes" expected to be of type "list"';
+
     {
       network_includes: converted,
     }
   ),
+
   "#withNetworkIncludesMixin":: "The zones to include",
   withNetworkIncludesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_includes" expected to be of type "list"';
+
     {
       network_includes+: converted,
     }
   ),
+
   "#withPolicyId":: "ID of the policy",
   withPolicyId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"policy_id" expected to be of type "string"';
+    assert std.isString(value) : '"policy_id" expected to be of type "string"';
+
     {
-      policy_id: converted,
+      policy_id: value,
     }
   ),
+
   "#withPriority":: "Priority of the rule.",
   withPriority(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+    assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
     {
-      priority: converted,
+      priority: value,
     }
   ),
+
   "#withReAuthenticationFrequency":: "The duration after which the end user must re-authenticate, regardless of user activity. Use the ISO 8601 Period format for recurring time intervals. PT0S - Every sign-in attempt, PT43800H - Once per session",
   withReAuthenticationFrequency(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"re_authentication_frequency" expected to be of type "string"';
+    assert std.isString(value) : '"re_authentication_frequency" expected to be of type "string"';
+
     {
-      re_authentication_frequency: converted,
+      re_authentication_frequency: value,
     }
   ),
+
   "#withRiskScore":: "The risk score specifies a particular level of risk to match on: ANY, LOW, MEDIUM, HIGH",
   withRiskScore(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"risk_score" expected to be of type "string"';
+    assert std.isString(value) : '"risk_score" expected to be of type "string"';
+
     {
-      risk_score: converted,
+      risk_score: value,
     }
   ),
+
   "#withStatus":: "Status of the rule",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withType":: "The Verification Method type",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
+
   "#withUserTypesExcluded":: "Set of User Type IDs to exclude",
   withUserTypesExcluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"user_types_excluded" expected to be of type "set"';
+
     {
       user_types_excluded: converted,
     }
   ),
+
   "#withUserTypesExcludedMixin":: "Set of User Type IDs to exclude",
   withUserTypesExcludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"user_types_excluded" expected to be of type "set"';
+
     {
       user_types_excluded+: converted,
     }
   ),
+
   "#withUserTypesIncluded":: "Set of User Type IDs to include",
   withUserTypesIncluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"user_types_included" expected to be of type "set"';
+
     {
       user_types_included: converted,
     }
   ),
+
   "#withUserTypesIncludedMixin":: "Set of User Type IDs to include",
   withUserTypesIncludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"user_types_included" expected to be of type "set"';
+
     {
       user_types_included+: converted,
     }
   ),
+
   "#withUsersExcluded":: "Set of User IDs to exclude",
   withUsersExcluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users_excluded" expected to be of type "set"';
+
     {
       users_excluded: converted,
     }
   ),
+
   "#withUsersExcludedMixin":: "Set of User IDs to exclude",
   withUsersExcludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users_excluded" expected to be of type "set"';
+
     {
       users_excluded+: converted,
     }
   ),
+
   "#withUsersIncluded":: "Set of User IDs to include",
   withUsersIncluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users_included" expected to be of type "set"';
+
     {
       users_included: converted,
     }
   ),
+
   "#withUsersIncludedMixin":: "Set of User IDs to include",
   withUsersIncludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users_included" expected to be of type "set"';
+
     {
       users_included+: converted,
     }
@@ -316,38 +376,43 @@
       },
     },
   },
+
   platformInclude:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     "#withOsExpression":: "Only available with OTHER OS type",
     withOsExpression(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"os_expression" expected to be of type "string"';
+      assert std.isString(value) : '"os_expression" expected to be of type "string"';
+
       {
-        os_expression: converted,
+        os_expression: value,
       }
     ),
+
     withOsType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"os_type" expected to be of type "string"';
+      assert std.isString(value) : '"os_type" expected to be of type "string"';
+
       {
-        os_type: converted,
+        os_type: value,
       }
     ),
+
     withType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"type" expected to be of type "string"';
+      assert std.isString(value) : '"type" expected to be of type "string"';
+
       {
-        type: converted,
+        type: value,
       }
     ),
   },
   withPlatformInclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      platform_include: value,
+      platform_include: converted,
     }
   ),
   withPlatformIncludeMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_swa.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_swa.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, label):: (
     {
       jsonnetTfMetadata:: {
@@ -13,203 +14,228 @@
     }
     + block.withLabel(label)
   ),
+
   "#withAccessibilityErrorRedirectUrl":: "Custom error page URL",
   withAccessibilityErrorRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_error_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_error_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_error_redirect_url: converted,
+      accessibility_error_redirect_url: value,
     }
   ),
+
   "#withAccessibilityLoginRedirectUrl":: "Custom login page URL",
   withAccessibilityLoginRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_login_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_login_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_login_redirect_url: converted,
+      accessibility_login_redirect_url: value,
     }
   ),
+
   "#withAccessibilitySelfService":: "Enable self service. Default is `false`",
   withAccessibilitySelfService(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"accessibility_self_service" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"accessibility_self_service" expected to be of type "bool"';
+
     {
-      accessibility_self_service: converted,
+      accessibility_self_service: value,
     }
   ),
+
   "#withAdminNote":: "Application notes for admins.",
   withAdminNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"admin_note" expected to be of type "string"';
+    assert std.isString(value) : '"admin_note" expected to be of type "string"';
+
     {
-      admin_note: converted,
+      admin_note: value,
     }
   ),
+
   "#withAppLinksJson":: "Displays specific appLinks for the app. The value for each application link should be boolean.",
   withAppLinksJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_links_json" expected to be of type "string"';
+    assert std.isString(value) : '"app_links_json" expected to be of type "string"';
+
     {
-      app_links_json: converted,
+      app_links_json: value,
     }
   ),
+
   "#withAutoSubmitToolbar":: "Display auto submit toolbar",
   withAutoSubmitToolbar(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"auto_submit_toolbar" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"auto_submit_toolbar" expected to be of type "bool"';
+
     {
-      auto_submit_toolbar: converted,
+      auto_submit_toolbar: value,
     }
   ),
+
   "#withButtonField":: "Login button field",
   withButtonField(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"button_field" expected to be of type "string"';
+    assert std.isString(value) : '"button_field" expected to be of type "string"';
+
     {
-      button_field: converted,
+      button_field: value,
     }
   ),
+
   "#withCheckbox":: "CSS selector for the checkbox",
   withCheckbox(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"checkbox" expected to be of type "string"';
+    assert std.isString(value) : '"checkbox" expected to be of type "string"';
+
     {
-      checkbox: converted,
+      checkbox: value,
     }
   ),
+
   "#withEnduserNote":: "Application notes for end users.",
   withEnduserNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"enduser_note" expected to be of type "string"';
+    assert std.isString(value) : '"enduser_note" expected to be of type "string"';
+
     {
-      enduser_note: converted,
+      enduser_note: value,
     }
   ),
+
   "#withHideIos":: "Do not display application icon on mobile app",
   withHideIos(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_ios" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_ios" expected to be of type "bool"';
+
     {
-      hide_ios: converted,
+      hide_ios: value,
     }
   ),
+
   "#withHideWeb":: "Do not display application icon to users",
   withHideWeb(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_web" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_web" expected to be of type "bool"';
+
     {
-      hide_web: converted,
+      hide_web: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLabel":: "The Application's display name.",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withLogo":: "Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.",
   withLogo(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"logo" expected to be of type "string"';
+    assert std.isString(value) : '"logo" expected to be of type "string"';
+
     {
-      logo: converted,
+      logo: value,
     }
   ),
+
   "#withPasswordField":: "Login password field",
   withPasswordField(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"password_field" expected to be of type "string"';
+    assert std.isString(value) : '"password_field" expected to be of type "string"';
+
     {
-      password_field: converted,
+      password_field: value,
     }
   ),
+
   "#withPreconfiguredApp":: "Preconfigured app name",
   withPreconfiguredApp(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"preconfigured_app" expected to be of type "string"';
+    assert std.isString(value) : '"preconfigured_app" expected to be of type "string"';
+
     {
-      preconfigured_app: converted,
+      preconfigured_app: value,
     }
   ),
+
   "#withRedirectUrl":: "If going to the login page URL redirects to another page, then enter that URL here",
   withRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"redirect_url" expected to be of type "string"';
+
     {
-      redirect_url: converted,
+      redirect_url: value,
     }
   ),
+
   "#withStatus":: "Status of application. By default, it is `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withUrl":: "Login URL",
   withUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"url" expected to be of type "string"';
+    assert std.isString(value) : '"url" expected to be of type "string"';
+
     {
-      url: converted,
+      url: value,
     }
   ),
+
   "#withUrlRegex":: "A regex that further restricts URL to the specified regex",
   withUrlRegex(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"url_regex" expected to be of type "string"';
+    assert std.isString(value) : '"url_regex" expected to be of type "string"';
+
     {
-      url_regex: converted,
+      url_regex: value,
     }
   ),
+
   "#withUserNameTemplate":: "Username template. Default: `${source.login}`",
   withUserNameTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template" expected to be of type "string"';
+
     {
-      user_name_template: converted,
+      user_name_template: value,
     }
   ),
+
   "#withUserNameTemplatePushStatus":: "Push username on update. Valid values: `PUSH` and `DONT_PUSH`",
   withUserNameTemplatePushStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_push_status" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_push_status" expected to be of type "string"';
+
     {
-      user_name_template_push_status: converted,
+      user_name_template_push_status: value,
     }
   ),
+
   "#withUserNameTemplateSuffix":: "Username template suffix",
   withUserNameTemplateSuffix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_suffix" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_suffix" expected to be of type "string"';
+
     {
-      user_name_template_suffix: converted,
+      user_name_template_suffix: value,
     }
   ),
+
   "#withUserNameTemplateType":: "Username template type. Default: `BUILT_IN`",
   withUserNameTemplateType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_type" expected to be of type "string"';
+
     {
-      user_name_template_type: converted,
+      user_name_template_type: value,
     }
   ),
+
   "#withUsernameField":: "Login username field",
   withUsernameField(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"username_field" expected to be of type "string"';
+    assert std.isString(value) : '"username_field" expected to be of type "string"';
+
     {
-      username_field: converted,
+      username_field: value,
     }
   ),
   withTerraformName(value):: {
@@ -219,35 +245,39 @@
       },
     },
   },
+
   timeouts:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withCreate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"create" expected to be of type "string"';
+      assert std.isString(value) : '"create" expected to be of type "string"';
+
       {
-        create: converted,
+        create: value,
       }
     ),
+
     withRead(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"read" expected to be of type "string"';
+      assert std.isString(value) : '"read" expected to be of type "string"';
+
       {
-        read: converted,
+        read: value,
       }
     ),
+
     withUpdate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"update" expected to be of type "string"';
+      assert std.isString(value) : '"update" expected to be of type "string"';
+
       {
-        update: converted,
+        update: value,
       }
     ),
   },
   withTimeouts(value):: (
-    local converted = value;
     {
       timeouts: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_three_field.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_three_field.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, buttonSelector, extraFieldSelector, extraFieldValue, label, passwordSelector, url, usernameSelector):: (
     {
       jsonnetTfMetadata:: {
@@ -19,227 +20,255 @@
     + block.withUrl(url)
     + block.withUsernameSelector(usernameSelector)
   ),
+
   "#withAccessibilityErrorRedirectUrl":: "Custom error page URL",
   withAccessibilityErrorRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_error_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_error_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_error_redirect_url: converted,
+      accessibility_error_redirect_url: value,
     }
   ),
+
   "#withAccessibilityLoginRedirectUrl":: "Custom login page URL",
   withAccessibilityLoginRedirectUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"accessibility_login_redirect_url" expected to be of type "string"';
+    assert std.isString(value) : '"accessibility_login_redirect_url" expected to be of type "string"';
+
     {
-      accessibility_login_redirect_url: converted,
+      accessibility_login_redirect_url: value,
     }
   ),
+
   "#withAccessibilitySelfService":: "Enable self service. Default is `false`",
   withAccessibilitySelfService(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"accessibility_self_service" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"accessibility_self_service" expected to be of type "bool"';
+
     {
-      accessibility_self_service: converted,
+      accessibility_self_service: value,
     }
   ),
+
   "#withAdminNote":: "Application notes for admins.",
   withAdminNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"admin_note" expected to be of type "string"';
+    assert std.isString(value) : '"admin_note" expected to be of type "string"';
+
     {
-      admin_note: converted,
+      admin_note: value,
     }
   ),
+
   "#withAppLinksJson":: "Displays specific appLinks for the app. The value for each application link should be boolean.",
   withAppLinksJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_links_json" expected to be of type "string"';
+    assert std.isString(value) : '"app_links_json" expected to be of type "string"';
+
     {
-      app_links_json: converted,
+      app_links_json: value,
     }
   ),
+
   "#withAutoSubmitToolbar":: "Display auto submit toolbar",
   withAutoSubmitToolbar(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"auto_submit_toolbar" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"auto_submit_toolbar" expected to be of type "bool"';
+
     {
-      auto_submit_toolbar: converted,
+      auto_submit_toolbar: value,
     }
   ),
+
   "#withButtonSelector":: "Login button field CSS selector",
   withButtonSelector(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"button_selector" expected to be of type "string"';
+    assert std.isString(value) : '"button_selector" expected to be of type "string"';
+
     {
-      button_selector: converted,
+      button_selector: value,
     }
   ),
+
   "#withCredentialsScheme":: "Application credentials scheme. One of: `EDIT_USERNAME_AND_PASSWORD`, `ADMIN_SETS_CREDENTIALS`, `EDIT_PASSWORD_ONLY`, `EXTERNAL_PASSWORD_SYNC`, or `SHARED_USERNAME_AND_PASSWORD`",
   withCredentialsScheme(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"credentials_scheme" expected to be of type "string"';
+    assert std.isString(value) : '"credentials_scheme" expected to be of type "string"';
+
     {
-      credentials_scheme: converted,
+      credentials_scheme: value,
     }
   ),
+
   "#withEnduserNote":: "Application notes for end users.",
   withEnduserNote(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"enduser_note" expected to be of type "string"';
+    assert std.isString(value) : '"enduser_note" expected to be of type "string"';
+
     {
-      enduser_note: converted,
+      enduser_note: value,
     }
   ),
+
   "#withExtraFieldSelector":: "Extra field CSS selector",
   withExtraFieldSelector(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"extra_field_selector" expected to be of type "string"';
+    assert std.isString(value) : '"extra_field_selector" expected to be of type "string"';
+
     {
-      extra_field_selector: converted,
+      extra_field_selector: value,
     }
   ),
+
   "#withExtraFieldValue":: "Value for extra form field",
   withExtraFieldValue(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"extra_field_value" expected to be of type "string"';
+    assert std.isString(value) : '"extra_field_value" expected to be of type "string"';
+
     {
-      extra_field_value: converted,
+      extra_field_value: value,
     }
   ),
+
   "#withHideIos":: "Do not display application icon on mobile app",
   withHideIos(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_ios" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_ios" expected to be of type "bool"';
+
     {
-      hide_ios: converted,
+      hide_ios: value,
     }
   ),
+
   "#withHideWeb":: "Do not display application icon to users",
   withHideWeb(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"hide_web" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"hide_web" expected to be of type "bool"';
+
     {
-      hide_web: converted,
+      hide_web: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLabel":: "The Application's display name.",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withLogo":: "Local file path to the logo. The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.",
   withLogo(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"logo" expected to be of type "string"';
+    assert std.isString(value) : '"logo" expected to be of type "string"';
+
     {
-      logo: converted,
+      logo: value,
     }
   ),
+
   "#withPasswordSelector":: "Login password field CSS selector",
   withPasswordSelector(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"password_selector" expected to be of type "string"';
+    assert std.isString(value) : '"password_selector" expected to be of type "string"';
+
     {
-      password_selector: converted,
+      password_selector: value,
     }
   ),
+
   "#withRevealPassword":: "Allow user to reveal password. It can not be set to `true` if `credentials_scheme` is `ADMIN_SETS_CREDENTIALS`, `SHARED_USERNAME_AND_PASSWORD` or `EXTERNAL_PASSWORD_SYNC`.",
   withRevealPassword(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"reveal_password" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"reveal_password" expected to be of type "bool"';
+
     {
-      reveal_password: converted,
+      reveal_password: value,
     }
   ),
+
   "#withSharedPassword":: "Shared password, required for certain schemes.",
   withSharedPassword(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"shared_password" expected to be of type "string"';
+    assert std.isString(value) : '"shared_password" expected to be of type "string"';
+
     {
-      shared_password: converted,
+      shared_password: value,
     }
   ),
+
   "#withSharedUsername":: "Shared username, required for certain schemes.",
   withSharedUsername(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"shared_username" expected to be of type "string"';
+    assert std.isString(value) : '"shared_username" expected to be of type "string"';
+
     {
-      shared_username: converted,
+      shared_username: value,
     }
   ),
+
   "#withStatus":: "Status of application. By default, it is `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withUrl":: "Login URL",
   withUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"url" expected to be of type "string"';
+    assert std.isString(value) : '"url" expected to be of type "string"';
+
     {
-      url: converted,
+      url: value,
     }
   ),
+
   "#withUrlRegex":: "A regex that further restricts URL to the specified regex",
   withUrlRegex(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"url_regex" expected to be of type "string"';
+    assert std.isString(value) : '"url_regex" expected to be of type "string"';
+
     {
-      url_regex: converted,
+      url_regex: value,
     }
   ),
+
   "#withUserNameTemplate":: "Username template. Default: `${source.login}`",
   withUserNameTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template" expected to be of type "string"';
+
     {
-      user_name_template: converted,
+      user_name_template: value,
     }
   ),
+
   "#withUserNameTemplatePushStatus":: "Push username on update. Valid values: `PUSH` and `DONT_PUSH`",
   withUserNameTemplatePushStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_push_status" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_push_status" expected to be of type "string"';
+
     {
-      user_name_template_push_status: converted,
+      user_name_template_push_status: value,
     }
   ),
+
   "#withUserNameTemplateSuffix":: "Username template suffix",
   withUserNameTemplateSuffix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_suffix" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_suffix" expected to be of type "string"';
+
     {
-      user_name_template_suffix: converted,
+      user_name_template_suffix: value,
     }
   ),
+
   "#withUserNameTemplateType":: "Username template type. Default: `BUILT_IN`",
   withUserNameTemplateType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name_template_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_name_template_type" expected to be of type "string"';
+
     {
-      user_name_template_type: converted,
+      user_name_template_type: value,
     }
   ),
+
   "#withUsernameSelector":: "Login username field CSS selector",
   withUsernameSelector(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"username_selector" expected to be of type "string"';
+    assert std.isString(value) : '"username_selector" expected to be of type "string"';
+
     {
-      username_selector: converted,
+      username_selector: value,
     }
   ),
   withTerraformName(value):: {
@@ -249,35 +278,39 @@
       },
     },
   },
+
   timeouts:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withCreate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"create" expected to be of type "string"';
+      assert std.isString(value) : '"create" expected to be of type "string"';
+
       {
-        create: converted,
+        create: value,
       }
     ),
+
     withRead(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"read" expected to be of type "string"';
+      assert std.isString(value) : '"read" expected to be of type "string"';
+
       {
-        read: converted,
+        read: value,
       }
     ),
+
     withUpdate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"update" expected to be of type "string"';
+      assert std.isString(value) : '"update" expected to be of type "string"';
+
       {
-        update: converted,
+        update: value,
       }
     ),
   },
   withTimeouts(value):: (
-    local converted = value;
     {
       timeouts: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_user.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_user.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, appId, userId):: (
     {
       jsonnetTfMetadata:: {
@@ -14,59 +15,66 @@
     + block.withAppId(appId)
     + block.withUserId(userId)
   ),
+
   "#withAppId":: "App to associate user with",
   withAppId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_id" expected to be of type "string"';
+    assert std.isString(value) : '"app_id" expected to be of type "string"';
+
     {
-      app_id: converted,
+      app_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withPassword":: "The password to use.",
   withPassword(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"password" expected to be of type "string"';
+    assert std.isString(value) : '"password" expected to be of type "string"';
+
     {
-      password: converted,
+      password: value,
     }
   ),
+
   "#withProfile":: "The JSON profile of the App User.",
   withProfile(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"profile" expected to be of type "string"';
+    assert std.isString(value) : '"profile" expected to be of type "string"';
+
     {
-      profile: converted,
+      profile: value,
     }
   ),
+
   "#withRetainAssignment":: "Retain the user assignment on destroy. If set to true, the resource will be removed from state but not from the Okta app.",
   withRetainAssignment(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"retain_assignment" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"retain_assignment" expected to be of type "bool"';
+
     {
-      retain_assignment: converted,
+      retain_assignment: value,
     }
   ),
+
   "#withUserId":: "User associated with the application",
   withUserId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_id" expected to be of type "string"';
+    assert std.isString(value) : '"user_id" expected to be of type "string"';
+
     {
-      user_id: converted,
+      user_id: value,
     }
   ),
+
   "#withUsername":: "The username to use for the app user. In case the user is assigned to the app with `SHARED_USERNAME_AND_PASSWORD` credentials scheme, this field will be computed and should not be set.",
   withUsername(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"username" expected to be of type "string"';
+    assert std.isString(value) : '"username" expected to be of type "string"';
+
     {
-      username: converted,
+      username: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_user_base_schema_property.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_user_base_schema_property.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, appId, index, title, type):: (
     {
       jsonnetTfMetadata:: {
@@ -16,83 +17,93 @@
     + block.withTitle(title)
     + block.withType(type)
   ),
+
   "#withAppId":: "The Application's ID the user schema property should be assigned to.",
   withAppId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_id" expected to be of type "string"';
+    assert std.isString(value) : '"app_id" expected to be of type "string"';
+
     {
-      app_id: converted,
+      app_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIndex":: "Subschema unique string identifier",
   withIndex(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"index" expected to be of type "string"';
+    assert std.isString(value) : '"index" expected to be of type "string"';
+
     {
-      index: converted,
+      index: value,
     }
   ),
+
   "#withMaster":: "Master priority for the user schema property. It can be set to `PROFILE_MASTER` or `OKTA`. Default: `PROFILE_MASTER`",
   withMaster(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"master" expected to be of type "string"';
+    assert std.isString(value) : '"master" expected to be of type "string"';
+
     {
-      master: converted,
+      master: value,
     }
   ),
+
   "#withPattern":: "The validation pattern to use for the subschema. Must be in form of '.+', or '[<pattern>]+' if present.'",
   withPattern(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"pattern" expected to be of type "string"';
+    assert std.isString(value) : '"pattern" expected to be of type "string"';
+
     {
-      pattern: converted,
+      pattern: value,
     }
   ),
+
   "#withPermissions":: "Access control permissions for the property. It can be set to `READ_WRITE`, `READ_ONLY`, `HIDE`. Default: `READ_ONLY`",
   withPermissions(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"permissions" expected to be of type "string"';
+    assert std.isString(value) : '"permissions" expected to be of type "string"';
+
     {
-      permissions: converted,
+      permissions: value,
     }
   ),
+
   "#withRequired":: "Whether the subschema is required",
   withRequired(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"required" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"required" expected to be of type "bool"';
+
     {
-      required: converted,
+      required: value,
     }
   ),
+
   "#withTitle":: "Subschema title (display name)",
   withTitle(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"title" expected to be of type "string"';
+    assert std.isString(value) : '"title" expected to be of type "string"';
+
     {
-      title: converted,
+      title: value,
     }
   ),
+
   "#withType":: "The type of the schema property. It can be `string`, `boolean`, `number`, `integer`, `array`, or `object`",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
+
   "#withUserType":: "User type ID. By default, it is `default`",
   withUserType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_type" expected to be of type "string"';
+
     {
-      user_type: converted,
+      user_type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_user_schema_property.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_app_user_schema_property.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, appId, index, title, type):: (
     {
       jsonnetTfMetadata:: {
@@ -16,179 +17,205 @@
     + block.withTitle(title)
     + block.withType(type)
   ),
+
   "#withAppId":: "The Application's ID the user custom schema property should be assigned to.",
   withAppId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"app_id" expected to be of type "string"';
+    assert std.isString(value) : '"app_id" expected to be of type "string"';
+
     {
-      app_id: converted,
+      app_id: value,
     }
   ),
+
   "#withArrayEnum":: "Array of values that an array property's items can be set to.",
   withArrayEnum(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"array_enum" expected to be of type "list"';
+
     {
       array_enum: converted,
     }
   ),
+
   "#withArrayEnumMixin":: "Array of values that an array property's items can be set to.",
   withArrayEnumMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"array_enum" expected to be of type "list"';
+
     {
       array_enum+: converted,
     }
   ),
+
   "#withArrayType":: "The type of the array elements if `type` is set to `array`",
   withArrayType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"array_type" expected to be of type "string"';
+    assert std.isString(value) : '"array_type" expected to be of type "string"';
+
     {
-      array_type: converted,
+      array_type: value,
     }
   ),
+
   "#withDescription":: "The description of the user schema property.",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   "#withEnum":: "Array of values a primitive property can be set to. See `array_enum` for arrays.",
   withEnum(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"enum" expected to be of type "list"';
+
     {
       enum: converted,
     }
   ),
+
   "#withEnumMixin":: "Array of values a primitive property can be set to. See `array_enum` for arrays.",
   withEnumMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"enum" expected to be of type "list"';
+
     {
       enum+: converted,
     }
   ),
+
   "#withExternalName":: "External name of the user schema property.",
   withExternalName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"external_name" expected to be of type "string"';
+    assert std.isString(value) : '"external_name" expected to be of type "string"';
+
     {
-      external_name: converted,
+      external_name: value,
     }
   ),
+
   "#withExternalNamespace":: "External namespace of the user schema property.",
   withExternalNamespace(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"external_namespace" expected to be of type "string"';
+    assert std.isString(value) : '"external_namespace" expected to be of type "string"';
+
     {
-      external_namespace: converted,
+      external_namespace: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIndex":: "Subschema unique string identifier",
   withIndex(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"index" expected to be of type "string"';
+    assert std.isString(value) : '"index" expected to be of type "string"';
+
     {
-      index: converted,
+      index: value,
     }
   ),
+
   "#withMaster":: "Master priority for the user schema property. It can be set to `PROFILE_MASTER` or `OKTA`",
   withMaster(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"master" expected to be of type "string"';
+    assert std.isString(value) : '"master" expected to be of type "string"';
+
     {
-      master: converted,
+      master: value,
     }
   ),
+
   "#withMaxLength":: "The maximum length of the user property value. Only applies to type `string`",
   withMaxLength(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"max_length" expected to be of type "number"';
+    assert std.isNumber(value) : '"max_length" expected to be of type "number"';
+
     {
-      max_length: converted,
+      max_length: value,
     }
   ),
+
   "#withMinLength":: "The minimum length of the user property value. Only applies to type `string`",
   withMinLength(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"min_length" expected to be of type "number"';
+    assert std.isNumber(value) : '"min_length" expected to be of type "number"';
+
     {
-      min_length: converted,
+      min_length: value,
     }
   ),
+
   "#withPermissions":: "Access control permissions for the property. It can be set to `READ_WRITE`, `READ_ONLY`, `HIDE`. Default: `READ_ONLY`",
   withPermissions(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"permissions" expected to be of type "string"';
+    assert std.isString(value) : '"permissions" expected to be of type "string"';
+
     {
-      permissions: converted,
+      permissions: value,
     }
   ),
+
   "#withRequired":: "Whether the subschema is required",
   withRequired(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"required" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"required" expected to be of type "bool"';
+
     {
-      required: converted,
+      required: value,
     }
   ),
+
   "#withScope":: "determines whether an app user attribute can be set at the Personal `SELF` or Group `NONE` level. Default value is `NONE`.",
   withScope(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"scope" expected to be of type "string"';
+    assert std.isString(value) : '"scope" expected to be of type "string"';
+
     {
-      scope: converted,
+      scope: value,
     }
   ),
+
   "#withTitle":: "Subschema title (display name)",
   withTitle(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"title" expected to be of type "string"';
+    assert std.isString(value) : '"title" expected to be of type "string"';
+
     {
-      title: converted,
+      title: value,
     }
   ),
+
   "#withType":: "The type of the schema property. It can be `string`, `boolean`, `number`, `integer`, `array`, or `object`",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
+
   "#withUnion":: "If `type` is set to `array`, used to set whether attribute value is determined by group priority `false`, or combine values across groups `true`. Can not be set to `true` if `scope` is set to `SELF`.",
   withUnion(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"union" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"union" expected to be of type "bool"';
+
     {
-      union: converted,
+      union: value,
     }
   ),
+
   "#withUnique":: "Whether the property should be unique. It can be set to `UNIQUE_VALIDATED` or `NOT_UNIQUE`.",
   withUnique(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"unique" expected to be of type "string"';
+    assert std.isString(value) : '"unique" expected to be of type "string"';
+
     {
-      unique: converted,
+      unique: value,
     }
   ),
+
   "#withUserType":: "User type ID. By default, it is `default`",
   withUserType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_type" expected to be of type "string"';
+
     {
-      user_type: converted,
+      user_type: value,
     }
   ),
   withTerraformName(value):: {
@@ -198,64 +225,71 @@
       },
     },
   },
+
   arrayOneOf:: {
     local block = self,
+
     new(const, title):: (
       {}
       + block.withConst(const)
       + block.withTitle(title)
     ),
+
     "#withConst":: "Value mapping to member of `array_enum`",
     withConst(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"const" expected to be of type "string"';
+      assert std.isString(value) : '"const" expected to be of type "string"';
+
       {
-        const: converted,
+        const: value,
       }
     ),
+
     "#withTitle":: "Display name for the enum value.",
     withTitle(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"title" expected to be of type "string"';
+      assert std.isString(value) : '"title" expected to be of type "string"';
+
       {
-        title: converted,
+        title: value,
       }
     ),
   },
   oneOf:: {
     local block = self,
+
     new(const, title):: (
       {}
       + block.withConst(const)
       + block.withTitle(title)
     ),
+
     "#withConst":: "Enum value",
     withConst(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"const" expected to be of type "string"';
+      assert std.isString(value) : '"const" expected to be of type "string"';
+
       {
-        const: converted,
+        const: value,
       }
     ),
+
     "#withTitle":: "Enum title",
     withTitle(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"title" expected to be of type "string"';
+      assert std.isString(value) : '"title" expected to be of type "string"';
+
       {
-        title: converted,
+        title: value,
       }
     ),
   },
   withArrayOneOf(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      array_one_of: value,
+      array_one_of: converted,
     }
   ),
   withOneOf(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      one_of: value,
+      one_of: converted,
     }
   ),
   withArrayOneOfMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, audiences, name):: (
     {
       jsonnetTfMetadata:: {
@@ -14,67 +15,77 @@
     + block.withAudiences(audiences)
     + block.withName(name)
   ),
+
   "#withAudiences":: "The recipients that the tokens are intended for. This becomes the `aud` claim in an access token. Currently Okta only supports a single value here.",
   withAudiences(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"audiences" expected to be of type "set"';
+
     {
       audiences: converted,
     }
   ),
+
   "#withAudiencesMixin":: "The recipients that the tokens are intended for. This becomes the `aud` claim in an access token. Currently Okta only supports a single value here.",
   withAudiencesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"audiences" expected to be of type "set"';
+
     {
       audiences+: converted,
     }
   ),
+
   "#withCredentialsRotationMode":: "The key rotation mode for the authorization server. Can be `AUTO` or `MANUAL`. Default: `AUTO`",
   withCredentialsRotationMode(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"credentials_rotation_mode" expected to be of type "string"';
+    assert std.isString(value) : '"credentials_rotation_mode" expected to be of type "string"';
+
     {
-      credentials_rotation_mode: converted,
+      credentials_rotation_mode: value,
     }
   ),
+
   "#withDescription":: "The description of the authorization server.",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIssuerMode":: "*Early Access Property*. Allows you to use a custom issuer URL. It can be set to `CUSTOM_URL`, `ORG_URL`, or `DYNAMIC`. Default: `ORG_URL`",
   withIssuerMode(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"issuer_mode" expected to be of type "string"';
+    assert std.isString(value) : '"issuer_mode" expected to be of type "string"';
+
     {
-      issuer_mode: converted,
+      issuer_mode: value,
     }
   ),
+
   "#withName":: "The name of the authorization server.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withStatus":: "Default to `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server_claim.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server_claim.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, authServerId, claimType, name, value):: (
     {
       jsonnetTfMetadata:: {
@@ -16,91 +17,104 @@
     + block.withName(name)
     + block.withValue(value)
   ),
+
   "#withAlwaysIncludeInToken":: "Specifies whether to include claims in token, by default it is set to `true`.",
   withAlwaysIncludeInToken(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"always_include_in_token" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"always_include_in_token" expected to be of type "bool"';
+
     {
-      always_include_in_token: converted,
+      always_include_in_token: value,
     }
   ),
+
   "#withAuthServerId":: "ID of the authorization server.",
   withAuthServerId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"auth_server_id" expected to be of type "string"';
+    assert std.isString(value) : '"auth_server_id" expected to be of type "string"';
+
     {
-      auth_server_id: converted,
+      auth_server_id: value,
     }
   ),
+
   "#withClaimType":: "Specifies whether the claim is for an access token `RESOURCE` or ID token `IDENTITY`.",
   withClaimType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"claim_type" expected to be of type "string"';
+    assert std.isString(value) : '"claim_type" expected to be of type "string"';
+
     {
-      claim_type: converted,
+      claim_type: value,
     }
   ),
+
   "#withGroupFilterType":: "Specifies the type of group filter if `value_type` is `GROUPS`. Can be set to one of the following `STARTS_WITH`, `EQUALS`, `CONTAINS`, `REGEX`.",
   withGroupFilterType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"group_filter_type" expected to be of type "string"';
+    assert std.isString(value) : '"group_filter_type" expected to be of type "string"';
+
     {
-      group_filter_type: converted,
+      group_filter_type: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "The name of the claim.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withScopes":: "The list of scopes the auth server claim is tied to.",
   withScopes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"scopes" expected to be of type "set"';
+
     {
       scopes: converted,
     }
   ),
+
   "#withScopesMixin":: "The list of scopes the auth server claim is tied to.",
   withScopesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"scopes" expected to be of type "set"';
+
     {
       scopes+: converted,
     }
   ),
+
   "#withStatus":: "Default to `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withValue":: "The value of the claim.",
   withValue(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"value" expected to be of type "string"';
+    assert std.isString(value) : '"value" expected to be of type "string"';
+
     {
-      value: converted,
+      value: value,
     }
   ),
+
   "#withValueType":: "The type of value of the claim. It can be set to `EXPRESSION` or `GROUPS`. It defaults to `EXPRESSION`.",
   withValueType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"value_type" expected to be of type "string"';
+    assert std.isString(value) : '"value_type" expected to be of type "string"';
+
     {
-      value_type: converted,
+      value_type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server_claim_default.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server_claim_default.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, authServerId, name):: (
     {
       jsonnetTfMetadata:: {
@@ -14,43 +15,48 @@
     + block.withAuthServerId(authServerId)
     + block.withName(name)
   ),
+
   "#withAlwaysIncludeInToken":: "Specifies whether to include claims in token.",
   withAlwaysIncludeInToken(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"always_include_in_token" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"always_include_in_token" expected to be of type "bool"';
+
     {
-      always_include_in_token: converted,
+      always_include_in_token: value,
     }
   ),
+
   "#withAuthServerId":: "ID of the authorization server.",
   withAuthServerId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"auth_server_id" expected to be of type "string"';
+    assert std.isString(value) : '"auth_server_id" expected to be of type "string"';
+
     {
-      auth_server_id: converted,
+      auth_server_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "The name of the claim. Can be set to `sub`, `address`, `birthdate`, `email`,`email_verified`, `family_name`, `gender`, `given_name`, `locale`, `middle_name`, `name`, `nickname`,`phone_number`, `picture`, `preferred_username`, `profile`, `updated_at`, `website`, `zoneinfo`",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withValue":: "The value of the claim. Only required for `sub` claim.",
   withValue(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"value" expected to be of type "string"';
+    assert std.isString(value) : '"value" expected to be of type "string"';
+
     {
-      value: converted,
+      value: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server_default.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server_default.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,67 +13,77 @@
       },
     }
   ),
+
   "#withAudiences":: "The recipients that the tokens are intended for. This becomes the `aud` claim in an access token. Currently Okta only supports a single value here.",
   withAudiences(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"audiences" expected to be of type "set"';
+
     {
       audiences: converted,
     }
   ),
+
   "#withAudiencesMixin":: "The recipients that the tokens are intended for. This becomes the `aud` claim in an access token. Currently Okta only supports a single value here.",
   withAudiencesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"audiences" expected to be of type "set"';
+
     {
       audiences+: converted,
     }
   ),
+
   "#withCredentialsRotationMode":: "The key rotation mode for the authorization server. Can be `AUTO` or `MANUAL`. Default: `MANUAL`.Credential rotation mode, in many cases you cannot set this to MANUAL, the API will ignore the value and you will get a perpetual diff. This should rarely be used.",
   withCredentialsRotationMode(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"credentials_rotation_mode" expected to be of type "string"';
+    assert std.isString(value) : '"credentials_rotation_mode" expected to be of type "string"';
+
     {
-      credentials_rotation_mode: converted,
+      credentials_rotation_mode: value,
     }
   ),
+
   "#withDescription":: "The description of the authorization server.",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIssuerMode":: "*Early Access Property*. Allows you to use a custom issuer URL. It can be set to `CUSTOM_URL`, `ORG_URL`, or `DYNAMIC`. Default: `ORG_URL`",
   withIssuerMode(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"issuer_mode" expected to be of type "string"';
+    assert std.isString(value) : '"issuer_mode" expected to be of type "string"';
+
     {
-      issuer_mode: converted,
+      issuer_mode: value,
     }
   ),
+
   "#withName":: "The name of the authorization server. Not necessary but left for backwards capacity with legacy implementation.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withStatus":: "Default to `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server_policy.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server_policy.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, authServerId, clientWhitelist, description, name, priority):: (
     {
       jsonnetTfMetadata:: {
@@ -17,67 +18,77 @@
     + block.withName(name)
     + block.withPriority(priority)
   ),
+
   "#withAuthServerId":: "The ID of the Auth Server.",
   withAuthServerId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"auth_server_id" expected to be of type "string"';
+    assert std.isString(value) : '"auth_server_id" expected to be of type "string"';
+
     {
-      auth_server_id: converted,
+      auth_server_id: value,
     }
   ),
+
   "#withClientWhitelist":: "The clients to whitelist the policy for. `[ALL_CLIENTS]` is a special value that can be used to whitelist all clients, otherwise it is a list of client ids.",
   withClientWhitelist(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"client_whitelist" expected to be of type "set"';
+
     {
       client_whitelist: converted,
     }
   ),
+
   "#withClientWhitelistMixin":: "The clients to whitelist the policy for. `[ALL_CLIENTS]` is a special value that can be used to whitelist all clients, otherwise it is a list of client ids.",
   withClientWhitelistMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"client_whitelist" expected to be of type "set"';
+
     {
       client_whitelist+: converted,
     }
   ),
+
   "#withDescription":: "The description of the Auth Server Policy.",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "The name of the Auth Server Policy.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withPriority":: "Priority of the auth server policy",
   withPriority(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+    assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
     {
-      priority: converted,
+      priority: value,
     }
   ),
+
   "#withStatus":: "Default to `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server_policy_rule.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server_policy_rule.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, authServerId, grantTypeWhitelist, name, policyId, priority):: (
     {
       jsonnetTfMetadata:: {
@@ -17,185 +18,220 @@
     + block.withPolicyId(policyId)
     + block.withPriority(priority)
   ),
+
   "#withAccessTokenLifetimeMinutes":: "Lifetime of access token. Can be set to a value between 5 and 1440 minutes. Default is `60`.",
   withAccessTokenLifetimeMinutes(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"access_token_lifetime_minutes" expected to be of type "number"';
+    assert std.isNumber(value) : '"access_token_lifetime_minutes" expected to be of type "number"';
+
     {
-      access_token_lifetime_minutes: converted,
+      access_token_lifetime_minutes: value,
     }
   ),
+
   "#withAuthServerId":: "Auth server ID",
   withAuthServerId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"auth_server_id" expected to be of type "string"';
+    assert std.isString(value) : '"auth_server_id" expected to be of type "string"';
+
     {
-      auth_server_id: converted,
+      auth_server_id: value,
     }
   ),
+
   "#withGrantTypeWhitelist":: "Accepted grant type values, `authorization_code`, `implicit`, `password`, `client_credentials`, `urn:ietf:params:oauth:grant-type:saml2-bearer` (*Early Access Property*), `urn:ietf:params:oauth:grant-type:token-exchange` (*Early Access Property*),`urn:ietf:params:oauth:grant-type:device_code` (*Early Access Property*), `interaction_code` (*OIE only*). For `implicit` value either `user_whitelist` or `group_whitelist` should be set.",
   withGrantTypeWhitelist(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"grant_type_whitelist" expected to be of type "set"';
+
     {
       grant_type_whitelist: converted,
     }
   ),
+
   "#withGrantTypeWhitelistMixin":: "Accepted grant type values, `authorization_code`, `implicit`, `password`, `client_credentials`, `urn:ietf:params:oauth:grant-type:saml2-bearer` (*Early Access Property*), `urn:ietf:params:oauth:grant-type:token-exchange` (*Early Access Property*),`urn:ietf:params:oauth:grant-type:device_code` (*Early Access Property*), `interaction_code` (*OIE only*). For `implicit` value either `user_whitelist` or `group_whitelist` should be set.",
   withGrantTypeWhitelistMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"grant_type_whitelist" expected to be of type "set"';
+
     {
       grant_type_whitelist+: converted,
     }
   ),
+
   "#withGroupBlacklist":: "Specifies a set of Groups whose Users are to be excluded.",
   withGroupBlacklist(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"group_blacklist" expected to be of type "set"';
+
     {
       group_blacklist: converted,
     }
   ),
+
   "#withGroupBlacklistMixin":: "Specifies a set of Groups whose Users are to be excluded.",
   withGroupBlacklistMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"group_blacklist" expected to be of type "set"';
+
     {
       group_blacklist+: converted,
     }
   ),
+
   "#withGroupWhitelist":: "Specifies a set of Groups whose Users are to be included. Can be set to Group ID or to the following: `EVERYONE`.",
   withGroupWhitelist(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"group_whitelist" expected to be of type "set"';
+
     {
       group_whitelist: converted,
     }
   ),
+
   "#withGroupWhitelistMixin":: "Specifies a set of Groups whose Users are to be included. Can be set to Group ID or to the following: `EVERYONE`.",
   withGroupWhitelistMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"group_whitelist" expected to be of type "set"';
+
     {
       group_whitelist+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withInlineHookId":: "The ID of the inline token to trigger.",
   withInlineHookId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"inline_hook_id" expected to be of type "string"';
+    assert std.isString(value) : '"inline_hook_id" expected to be of type "string"';
+
     {
-      inline_hook_id: converted,
+      inline_hook_id: value,
     }
   ),
+
   "#withName":: "Auth server policy rule name",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withPolicyId":: "Auth server policy ID",
   withPolicyId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"policy_id" expected to be of type "string"';
+    assert std.isString(value) : '"policy_id" expected to be of type "string"';
+
     {
-      policy_id: converted,
+      policy_id: value,
     }
   ),
+
   "#withPriority":: "Priority of the auth server policy rule",
   withPriority(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+    assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
     {
-      priority: converted,
+      priority: value,
     }
   ),
+
   "#withRefreshTokenLifetimeMinutes":: "Lifetime of refresh token.",
   withRefreshTokenLifetimeMinutes(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"refresh_token_lifetime_minutes" expected to be of type "number"';
+    assert std.isNumber(value) : '"refresh_token_lifetime_minutes" expected to be of type "number"';
+
     {
-      refresh_token_lifetime_minutes: converted,
+      refresh_token_lifetime_minutes: value,
     }
   ),
+
   "#withRefreshTokenWindowMinutes":: "Window in which a refresh token can be used. It can be a value between 5 and 2628000 (5 years) minutes. Default is `10080` (7 days).`refresh_token_window_minutes` must be between `access_token_lifetime_minutes` and `refresh_token_lifetime_minutes`.",
   withRefreshTokenWindowMinutes(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"refresh_token_window_minutes" expected to be of type "number"';
+    assert std.isNumber(value) : '"refresh_token_window_minutes" expected to be of type "number"';
+
     {
-      refresh_token_window_minutes: converted,
+      refresh_token_window_minutes: value,
     }
   ),
+
   "#withScopeWhitelist":: "Scopes allowed for this policy rule. They can be whitelisted by name or all can be whitelisted with ` * `",
   withScopeWhitelist(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"scope_whitelist" expected to be of type "set"';
+
     {
       scope_whitelist: converted,
     }
   ),
+
   "#withScopeWhitelistMixin":: "Scopes allowed for this policy rule. They can be whitelisted by name or all can be whitelisted with ` * `",
   withScopeWhitelistMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"scope_whitelist" expected to be of type "set"';
+
     {
       scope_whitelist+: converted,
     }
   ),
+
   "#withStatus":: "Default to `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withType":: "Auth server policy rule type, unlikely this will be anything other then the default",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
+
   "#withUserBlacklist":: "Specifies a set of Users to be excluded.",
   withUserBlacklist(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"user_blacklist" expected to be of type "set"';
+
     {
       user_blacklist: converted,
     }
   ),
+
   "#withUserBlacklistMixin":: "Specifies a set of Users to be excluded.",
   withUserBlacklistMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"user_blacklist" expected to be of type "set"';
+
     {
       user_blacklist+: converted,
     }
   ),
+
   "#withUserWhitelist":: "Specifies a set of Users to be included.",
   withUserWhitelist(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"user_whitelist" expected to be of type "set"';
+
     {
       user_whitelist: converted,
     }
   ),
+
   "#withUserWhitelistMixin":: "Specifies a set of Users to be included.",
   withUserWhitelistMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"user_whitelist" expected to be of type "set"';
+
     {
       user_whitelist+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server_scope.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_auth_server_scope.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, authServerId, name):: (
     {
       jsonnetTfMetadata:: {
@@ -14,75 +15,84 @@
     + block.withAuthServerId(authServerId)
     + block.withName(name)
   ),
+
   "#withAuthServerId":: "Auth server ID",
   withAuthServerId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"auth_server_id" expected to be of type "string"';
+    assert std.isString(value) : '"auth_server_id" expected to be of type "string"';
+
     {
-      auth_server_id: converted,
+      auth_server_id: value,
     }
   ),
+
   "#withConsent":: "Indicates whether a consent dialog is needed for the scope. It can be set to `REQUIRED` or `IMPLICIT`. Default: `IMPLICIT`",
   withConsent(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"consent" expected to be of type "string"';
+    assert std.isString(value) : '"consent" expected to be of type "string"';
+
     {
-      consent: converted,
+      consent: value,
     }
   ),
+
   "#withDefault":: "A default scope will be returned in an access token when the client omits the scope parameter in a token request, provided this scope is allowed as part of the access policy rule.",
   withDefault(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"default" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"default" expected to be of type "bool"';
+
     {
-      default: converted,
+      default: value,
     }
   ),
+
   "#withDescription":: "Description of the Auth Server Scope.",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   "#withDisplayName":: "Name of the end user displayed in a consent dialog box",
   withDisplayName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"display_name" expected to be of type "string"';
+    assert std.isString(value) : '"display_name" expected to be of type "string"';
+
     {
-      display_name: converted,
+      display_name: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withMetadataPublish":: "Whether to publish metadata or not. It can be set to `ALL_CLIENTS` or `NO_CLIENTS`. Default: `ALL_CLIENTS`",
   withMetadataPublish(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"metadata_publish" expected to be of type "string"';
+    assert std.isString(value) : '"metadata_publish" expected to be of type "string"';
+
     {
-      metadata_publish: converted,
+      metadata_publish: value,
     }
   ),
+
   "#withName":: "Auth server scope name",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withOptional":: "Whether the scope optional",
   withOptional(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"optional" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"optional" expected to be of type "bool"';
+
     {
-      optional: converted,
+      optional: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_authenticator.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_authenticator.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, key, name):: (
     {
       jsonnetTfMetadata:: {
@@ -14,115 +15,129 @@
     + block.withKey(key)
     + block.withName(name)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withKey":: "A human-readable string that identifies the authenticator. Some authenticators are available by feature flag on the organization. Possible values inclue: `duo`, `external_idp`, `google_otp`, `okta_email`, `okta_password`, `okta_verify`, `onprem_mfa`, `phone_number`, `rsa_token`, `security_question`, `webauthn`",
   withKey(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"key" expected to be of type "string"';
+    assert std.isString(value) : '"key" expected to be of type "string"';
+
     {
-      key: converted,
+      key: value,
     }
   ),
+
   "#withLegacyIgnoreName":: "Name does not trigger change detection (legacy behavior)",
   withLegacyIgnoreName(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"legacy_ignore_name" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"legacy_ignore_name" expected to be of type "bool"';
+
     {
-      legacy_ignore_name: converted,
+      legacy_ignore_name: value,
     }
   ),
+
   "#withName":: "Display name of the Authenticator",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withProviderAuthPort":: "The RADIUS server port (for example 1812). This is defined when the On-Prem RADIUS server is configured. Used only for authenticators with type `security_key`.  Conflicts with `provider_json` argument.",
   withProviderAuthPort(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"provider_auth_port" expected to be of type "number"';
+    assert std.isNumber(value) : '"provider_auth_port" expected to be of type "number"';
+
     {
-      provider_auth_port: converted,
+      provider_auth_port: value,
     }
   ),
+
   "#withProviderHost":: "(DUO specific) - The Duo Security API hostname. Conflicts with `provider_json` argument.",
   withProviderHost(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"provider_host" expected to be of type "string"';
+    assert std.isString(value) : '"provider_host" expected to be of type "string"';
+
     {
-      provider_host: converted,
+      provider_host: value,
     }
   ),
+
   "#withProviderHostname":: "Server host name or IP address. Default is `localhost`. Used only for authenticators with type `security_key`. Conflicts with `provider_json` argument.",
   withProviderHostname(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"provider_hostname" expected to be of type "string"';
+    assert std.isString(value) : '"provider_hostname" expected to be of type "string"';
+
     {
-      provider_hostname: converted,
+      provider_hostname: value,
     }
   ),
+
   "#withProviderIntegrationKey":: "(DUO specific) - The Duo Security integration key.  Conflicts with `provider_json` argument.",
   withProviderIntegrationKey(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"provider_integration_key" expected to be of type "string"';
+    assert std.isString(value) : '"provider_integration_key" expected to be of type "string"';
+
     {
-      provider_integration_key: converted,
+      provider_integration_key: value,
     }
   ),
+
   "#withProviderJson":: "Provider JSON allows for expressive providervalues. This argument conflicts with the other 'provider_xxx' arguments. The [CreateProvider](https://developer.okta.com/docs/reference/api/authenticators-admin/#request) illustrates detailed provider values for a Duo authenticator. [Provider values](https://developer.okta.com/docs/reference/api/authenticators-admin/#authenticators-administration-api-object)are listed in Okta API.",
   withProviderJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"provider_json" expected to be of type "string"';
+    assert std.isString(value) : '"provider_json" expected to be of type "string"';
+
     {
-      provider_json: converted,
+      provider_json: value,
     }
   ),
+
   "#withProviderSecretKey":: "(DUO specific) - The Duo Security secret key.  Conflicts with `provider_json` argument.",
   withProviderSecretKey(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"provider_secret_key" expected to be of type "string"';
+    assert std.isString(value) : '"provider_secret_key" expected to be of type "string"';
+
     {
-      provider_secret_key: converted,
+      provider_secret_key: value,
     }
   ),
+
   "#withProviderSharedSecret":: "An authentication key that must be defined when the RADIUS server is configured, and must be the same on both the RADIUS client and server. Used only for authenticators with type `security_key`. Conflicts with `provider_json` argument.",
   withProviderSharedSecret(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"provider_shared_secret" expected to be of type "string"';
+    assert std.isString(value) : '"provider_shared_secret" expected to be of type "string"';
+
     {
-      provider_shared_secret: converted,
+      provider_shared_secret: value,
     }
   ),
+
   "#withProviderUserNameTemplate":: "Username template expected by the provider. Used only for authenticators with type `security_key`.  Conflicts with `provider_json` argument.",
   withProviderUserNameTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"provider_user_name_template" expected to be of type "string"';
+    assert std.isString(value) : '"provider_user_name_template" expected to be of type "string"';
+
     {
-      provider_user_name_template: converted,
+      provider_user_name_template: value,
     }
   ),
+
   "#withSettings":: "Settings for the authenticator. The settings JSON contains values based on Authenticator key. It is not used for authenticators with type `security_key`",
   withSettings(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"settings" expected to be of type "string"';
+    assert std.isString(value) : '"settings" expected to be of type "string"';
+
     {
-      settings: converted,
+      settings: value,
     }
   ),
+
   "#withStatus":: "Authenticator status: `ACTIVE` or `INACTIVE`. Default: `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_behavior.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_behavior.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name, type):: (
     {
       jsonnetTfMetadata:: {
@@ -14,67 +15,75 @@
     + block.withName(name)
     + block.withType(type)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLocationGranularityType":: "Determines the method and level of detail used to evaluate the behavior. Required for `ANOMALOUS_LOCATION` behavior type. Can be set to `LAT_LONG`, `CITY`, `COUNTRY` or `SUBDIVISION`.",
   withLocationGranularityType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"location_granularity_type" expected to be of type "string"';
+    assert std.isString(value) : '"location_granularity_type" expected to be of type "string"';
+
     {
-      location_granularity_type: converted,
+      location_granularity_type: value,
     }
   ),
+
   "#withName":: "Name of the behavior",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withNumberOfAuthentications":: "The number of recent authentications used to evaluate the behavior. Required for `ANOMALOUS_LOCATION`, `ANOMALOUS_DEVICE` and `ANOMALOUS_IP` behavior types.",
   withNumberOfAuthentications(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"number_of_authentications" expected to be of type "number"';
+    assert std.isNumber(value) : '"number_of_authentications" expected to be of type "number"';
+
     {
-      number_of_authentications: converted,
+      number_of_authentications: value,
     }
   ),
+
   "#withRadiusFromLocation":: "Radius from location (in kilometers). Should be at least 5. Required when `location_granularity_type` is set to `LAT_LONG`.",
   withRadiusFromLocation(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"radius_from_location" expected to be of type "number"';
+    assert std.isNumber(value) : '"radius_from_location" expected to be of type "number"';
+
     {
-      radius_from_location: converted,
+      radius_from_location: value,
     }
   ),
+
   "#withStatus":: "Behavior status: ACTIVE or INACTIVE. Default: `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withType":: "Type of the behavior. Can be set to `ANOMALOUS_LOCATION`, `ANOMALOUS_DEVICE`, `ANOMALOUS_IP` or `VELOCITY`. Resource will be recreated when the type changes.e",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
+
   "#withVelocity":: "Velocity (in kilometers per hour). Should be at least 1. Required for `VELOCITY` behavior",
   withVelocity(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"velocity" expected to be of type "number"';
+    assert std.isNumber(value) : '"velocity" expected to be of type "number"';
+
     {
-      velocity: converted,
+      velocity: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_brand.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_brand.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,76 +14,85 @@
     }
     + block.withName(name)
   ),
+
   "#withAgreeToCustomPrivacyPolicy":: "Is a required input flag with when changing custom_privacy_url, shouldn't be considered as a readable property",
   withAgreeToCustomPrivacyPolicy(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"agree_to_custom_privacy_policy" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"agree_to_custom_privacy_policy" expected to be of type "bool"';
+
     {
-      agree_to_custom_privacy_policy: converted,
+      agree_to_custom_privacy_policy: value,
     }
   ),
+
   "#withBrandId":: "Brand ID - Note: Okta API for brands only reads and updates therefore the okta_brand resource needs to act as a quasi data source. Do this by setting brand_id. `DEPRECATED`: Okta has fully support brand creation, this attribute is a no op and will be removed",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   "#withCustomPrivacyPolicyUrl":: "Custom privacy policy URL",
   withCustomPrivacyPolicyUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"custom_privacy_policy_url" expected to be of type "string"';
+    assert std.isString(value) : '"custom_privacy_policy_url" expected to be of type "string"';
+
     {
-      custom_privacy_policy_url: converted,
+      custom_privacy_policy_url: value,
     }
   ),
+
   "#withDefaultAppAppInstanceId":: "Default app app instance id",
   withDefaultAppAppInstanceId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"default_app_app_instance_id" expected to be of type "string"';
+    assert std.isString(value) : '"default_app_app_instance_id" expected to be of type "string"';
+
     {
-      default_app_app_instance_id: converted,
+      default_app_app_instance_id: value,
     }
   ),
+
   "#withDefaultAppAppLinkName":: "Default app app link name",
   withDefaultAppAppLinkName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"default_app_app_link_name" expected to be of type "string"';
+    assert std.isString(value) : '"default_app_app_link_name" expected to be of type "string"';
+
     {
-      default_app_app_link_name: converted,
+      default_app_app_link_name: value,
     }
   ),
+
   "#withDefaultAppClassicApplicationUri":: "Default app classic application uri",
   withDefaultAppClassicApplicationUri(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"default_app_classic_application_uri" expected to be of type "string"';
+    assert std.isString(value) : '"default_app_classic_application_uri" expected to be of type "string"';
+
     {
-      default_app_classic_application_uri: converted,
+      default_app_classic_application_uri: value,
     }
   ),
+
   "#withLocale":: "The language specified as an IETF BCP 47 language tag",
   withLocale(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"locale" expected to be of type "string"';
+    assert std.isString(value) : '"locale" expected to be of type "string"';
+
     {
-      locale: converted,
+      locale: value,
     }
   ),
+
   "#withName":: "Name of the brand",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withRemovePoweredByOkta":: "Removes 'Powered by Okta' from the Okta-hosted sign-in page and '© 2021 Okta, Inc.' from the Okta End-User Dashboard",
   withRemovePoweredByOkta(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"remove_powered_by_okta" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"remove_powered_by_okta" expected to be of type "bool"';
+
     {
-      remove_powered_by_okta: converted,
+      remove_powered_by_okta: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_captcha.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_captcha.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name, secretKey, siteKey, type):: (
     {
       jsonnetTfMetadata:: {
@@ -16,43 +17,48 @@
     + block.withSiteKey(siteKey)
     + block.withType(type)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Name of the CAPTCHA",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withSecretKey":: "Secret key issued from the CAPTCHA vendor to perform server-side validation for a CAPTCHA token",
   withSecretKey(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"secret_key" expected to be of type "string"';
+    assert std.isString(value) : '"secret_key" expected to be of type "string"';
+
     {
-      secret_key: converted,
+      secret_key: value,
     }
   ),
+
   "#withSiteKey":: "Site key issued from the CAPTCHA vendor to render a CAPTCHA on a page",
   withSiteKey(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"site_key" expected to be of type "string"';
+    assert std.isString(value) : '"site_key" expected to be of type "string"';
+
     {
-      site_key: converted,
+      site_key: value,
     }
   ),
+
   "#withType":: "Type of the captcha. Valid values: `HCAPTCHA`, `RECAPTCHA_V2`",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_captcha_org_wide_settings.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_captcha_org_wide_settings.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,35 +13,41 @@
       },
     }
   ),
+
   "#withCaptchaId":: "Array of pages that have CAPTCHA enabled. Valid values: `SSR`, `SSPR` and `SIGN_IN`.",
   withCaptchaId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"captcha_id" expected to be of type "string"';
+    assert std.isString(value) : '"captcha_id" expected to be of type "string"';
+
     {
-      captcha_id: converted,
+      captcha_id: value,
     }
   ),
+
   "#withEnabledFor":: "Set of pages that have CAPTCHA enabled",
   withEnabledFor(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"enabled_for" expected to be of type "set"';
+
     {
       enabled_for: converted,
     }
   ),
+
   "#withEnabledForMixin":: "Set of pages that have CAPTCHA enabled",
   withEnabledForMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"enabled_for" expected to be of type "set"';
+
     {
       enabled_for+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_customized_signin_page.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_customized_signin_page.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId, pageContent, widgetVersion):: (
     {
       jsonnetTfMetadata:: {
@@ -15,28 +16,31 @@
     + block.withPageContent(pageContent)
     + block.withWidgetVersion(widgetVersion)
   ),
+
   "#withBrandId":: "brand id of the preview signin page",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   "#withPageContent":: "page content of the preview signin page",
   withPageContent(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"page_content" expected to be of type "string"';
+    assert std.isString(value) : '"page_content" expected to be of type "string"';
+
     {
-      page_content: converted,
+      page_content: value,
     }
   ),
+
   "#withWidgetVersion":: "widget version specified as a Semver. The following are currently supported \t\t\t*, ^1, ^2, ^3, ^4, ^5, ^6, ^7, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 2.1, 2.2, 2.3, 2.4, \t\t\t2.5, 2.6, 2.7, 2.8, 2.9, 2.10, 2.11, 2.12, 2.13, 2.14, 2.15, 2.16, 2.17, 2.18, 2.19, 2.20, 2.21, \t\t\t3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 5.0, 5.1, 5.2, 5.3, \t\t\t5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 5.10, 5.11, 5.12, 5.13, 5.14, 5.15, 5.16, 6.0, 6.1, 6.2, 6.3, 6.4, 6.5, \t\t\t6.6, 6.7, 6.8, 6.9, 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 7.10, 7.11, 7.12, 7.13.",
   withWidgetVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"widget_version" expected to be of type "string"';
+    assert std.isString(value) : '"widget_version" expected to be of type "string"';
+
     {
-      widget_version: converted,
+      widget_version: value,
     }
   ),
   withTerraformName(value):: {
@@ -46,36 +50,44 @@
       },
     },
   },
+
   contentSecurityPolicySetting:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     "#withMode":: "enforced or report_only",
     withMode(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"mode" expected to be of type "string"';
+      assert std.isString(value) : '"mode" expected to be of type "string"';
+
       {
-        mode: converted,
+        mode: value,
       }
     ),
+
     withReportUri(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"report_uri" expected to be of type "string"';
+      assert std.isString(value) : '"report_uri" expected to be of type "string"';
+
       {
-        report_uri: converted,
+        report_uri: value,
       }
     ),
+
     withSrcList(value):: (
       local converted = if std.isArray(value) then value else [value];
       assert std.isArray(converted) : '"src_list" expected to be of type "list"';
+
       {
         src_list: converted,
       }
     ),
+
     withSrcListMixin(value):: (
       local converted = if std.isArray(value) then value else [value];
       assert std.isArray(converted) : '"src_list" expected to be of type "list"';
+
       {
         src_list+: converted,
       }
@@ -83,166 +95,186 @@
   },
   widgetCustomizations:: {
     local block = self,
+
     new(widgetGeneration):: (
       {}
       + block.withWidgetGeneration(widgetGeneration)
     ),
+
     withAuthenticatorPageCustomLinkLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"authenticator_page_custom_link_label" expected to be of type "string"';
+      assert std.isString(value) : '"authenticator_page_custom_link_label" expected to be of type "string"';
+
       {
-        authenticator_page_custom_link_label: converted,
+        authenticator_page_custom_link_label: value,
       }
     ),
+
     withAuthenticatorPageCustomLinkUrl(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"authenticator_page_custom_link_url" expected to be of type "string"';
+      assert std.isString(value) : '"authenticator_page_custom_link_url" expected to be of type "string"';
+
       {
-        authenticator_page_custom_link_url: converted,
+        authenticator_page_custom_link_url: value,
       }
     ),
+
     withClassicRecoveryFlowEmailOrUsernameLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"classic_recovery_flow_email_or_username_label" expected to be of type "string"';
+      assert std.isString(value) : '"classic_recovery_flow_email_or_username_label" expected to be of type "string"';
+
       {
-        classic_recovery_flow_email_or_username_label: converted,
+        classic_recovery_flow_email_or_username_label: value,
       }
     ),
+
     withCustomLink_1Label(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"custom_link_1_label" expected to be of type "string"';
+      assert std.isString(value) : '"custom_link_1_label" expected to be of type "string"';
+
       {
-        custom_link_1_label: converted,
+        custom_link_1_label: value,
       }
     ),
+
     withCustomLink_1Url(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"custom_link_1_url" expected to be of type "string"';
+      assert std.isString(value) : '"custom_link_1_url" expected to be of type "string"';
+
       {
-        custom_link_1_url: converted,
+        custom_link_1_url: value,
       }
     ),
+
     withCustomLink_2Label(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"custom_link_2_label" expected to be of type "string"';
+      assert std.isString(value) : '"custom_link_2_label" expected to be of type "string"';
+
       {
-        custom_link_2_label: converted,
+        custom_link_2_label: value,
       }
     ),
+
     withCustomLink_2Url(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"custom_link_2_url" expected to be of type "string"';
+      assert std.isString(value) : '"custom_link_2_url" expected to be of type "string"';
+
       {
-        custom_link_2_url: converted,
+        custom_link_2_url: value,
       }
     ),
+
     withForgotPasswordLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"forgot_password_label" expected to be of type "string"';
+      assert std.isString(value) : '"forgot_password_label" expected to be of type "string"';
+
       {
-        forgot_password_label: converted,
+        forgot_password_label: value,
       }
     ),
+
     withForgotPasswordUrl(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"forgot_password_url" expected to be of type "string"';
+      assert std.isString(value) : '"forgot_password_url" expected to be of type "string"';
+
       {
-        forgot_password_url: converted,
+        forgot_password_url: value,
       }
     ),
+
     withHelpLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"help_label" expected to be of type "string"';
+      assert std.isString(value) : '"help_label" expected to be of type "string"';
+
       {
-        help_label: converted,
+        help_label: value,
       }
     ),
+
     withHelpUrl(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"help_url" expected to be of type "string"';
+      assert std.isString(value) : '"help_url" expected to be of type "string"';
+
       {
-        help_url: converted,
+        help_url: value,
       }
     ),
+
     withPasswordInfoTip(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"password_info_tip" expected to be of type "string"';
+      assert std.isString(value) : '"password_info_tip" expected to be of type "string"';
+
       {
-        password_info_tip: converted,
+        password_info_tip: value,
       }
     ),
+
     withPasswordLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"password_label" expected to be of type "string"';
+      assert std.isString(value) : '"password_label" expected to be of type "string"';
+
       {
-        password_label: converted,
+        password_label: value,
       }
     ),
+
     withShowPasswordVisibilityToggle(value):: (
-      local converted = value;
-      assert std.isBoolean(converted) : '"show_password_visibility_toggle" expected to be of type "bool"';
+      assert std.isBoolean(value) : '"show_password_visibility_toggle" expected to be of type "bool"';
+
       {
-        show_password_visibility_toggle: converted,
+        show_password_visibility_toggle: value,
       }
     ),
+
     withShowUserIdentifier(value):: (
-      local converted = value;
-      assert std.isBoolean(converted) : '"show_user_identifier" expected to be of type "bool"';
+      assert std.isBoolean(value) : '"show_user_identifier" expected to be of type "bool"';
+
       {
-        show_user_identifier: converted,
+        show_user_identifier: value,
       }
     ),
+
     withSignInLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"sign_in_label" expected to be of type "string"';
+      assert std.isString(value) : '"sign_in_label" expected to be of type "string"';
+
       {
-        sign_in_label: converted,
+        sign_in_label: value,
       }
     ),
+
     withUnlockAccountLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"unlock_account_label" expected to be of type "string"';
+      assert std.isString(value) : '"unlock_account_label" expected to be of type "string"';
+
       {
-        unlock_account_label: converted,
+        unlock_account_label: value,
       }
     ),
+
     withUnlockAccountUrl(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"unlock_account_url" expected to be of type "string"';
+      assert std.isString(value) : '"unlock_account_url" expected to be of type "string"';
+
       {
-        unlock_account_url: converted,
+        unlock_account_url: value,
       }
     ),
+
     withUsernameInfoTip(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"username_info_tip" expected to be of type "string"';
+      assert std.isString(value) : '"username_info_tip" expected to be of type "string"';
+
       {
-        username_info_tip: converted,
+        username_info_tip: value,
       }
     ),
+
     withUsernameLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"username_label" expected to be of type "string"';
+      assert std.isString(value) : '"username_label" expected to be of type "string"';
+
       {
-        username_label: converted,
+        username_label: value,
       }
     ),
+
     withWidgetGeneration(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"widget_generation" expected to be of type "string"';
+      assert std.isString(value) : '"widget_generation" expected to be of type "string"';
+
       {
-        widget_generation: converted,
+        widget_generation: value,
       }
     ),
   },
   withContentSecurityPolicySetting(value):: (
-    local converted = value;
     {
       content_security_policy_setting: value,
     }
   ),
   withWidgetCustomizations(value):: (
-    local converted = value;
     {
       widget_customizations: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_domain.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_domain.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,35 +14,39 @@
     }
     + block.withName(name)
   ),
+
   "#withBrandId":: "Brand id of the domain",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   "#withCertificateSourceType":: "Certificate source type that indicates whether the certificate is provided by the user or Okta. Accepted values: `MANUAL`, `OKTA_MANAGED`. Warning: Use of OKTA_MANAGED requires a feature flag to be enabled. Default value = MANUAL",
   withCertificateSourceType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"certificate_source_type" expected to be of type "string"';
+    assert std.isString(value) : '"certificate_source_type" expected to be of type "string"';
+
     {
-      certificate_source_type: converted,
+      certificate_source_type: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Custom Domain name",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_domain_certificate.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_domain_certificate.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, certificate, certificateChain, domainId, privateKey):: (
     {
       jsonnetTfMetadata:: {
@@ -16,51 +17,57 @@
     + block.withDomainId(domainId)
     + block.withPrivateKey(privateKey)
   ),
+
   "#withCertificate":: "Certificate content",
   withCertificate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"certificate" expected to be of type "string"';
+    assert std.isString(value) : '"certificate" expected to be of type "string"';
+
     {
-      certificate: converted,
+      certificate: value,
     }
   ),
+
   "#withCertificateChain":: "Certificate chain",
   withCertificateChain(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"certificate_chain" expected to be of type "string"';
+    assert std.isString(value) : '"certificate_chain" expected to be of type "string"';
+
     {
-      certificate_chain: converted,
+      certificate_chain: value,
     }
   ),
+
   "#withDomainId":: "Domain's ID",
   withDomainId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"domain_id" expected to be of type "string"';
+    assert std.isString(value) : '"domain_id" expected to be of type "string"';
+
     {
-      domain_id: converted,
+      domain_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withPrivateKey":: "Certificate private key",
   withPrivateKey(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"private_key" expected to be of type "string"';
+    assert std.isString(value) : '"private_key" expected to be of type "string"';
+
     {
-      private_key: converted,
+      private_key: value,
     }
   ),
+
   "#withType":: "Certificate type. Valid value is `PEM`",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_domain_verification.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_domain_verification.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, domainId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,19 +14,21 @@
     }
     + block.withDomainId(domainId)
   ),
+
   "#withDomainId":: "Domain's ID",
   withDomainId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"domain_id" expected to be of type "string"';
+    assert std.isString(value) : '"domain_id" expected to be of type "string"';
+
     {
-      domain_id: converted,
+      domain_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_customization.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_customization.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId, templateName):: (
     {
       jsonnetTfMetadata:: {
@@ -14,60 +15,67 @@
     + block.withBrandId(brandId)
     + block.withTemplateName(templateName)
   ),
+
   "#withBody":: "The body of the customization",
   withBody(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"body" expected to be of type "string"';
+    assert std.isString(value) : '"body" expected to be of type "string"';
+
     {
-      body: converted,
+      body: value,
     }
   ),
+
   "#withBrandId":: "Brand ID",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   "#withForceIsDefault":: "Force is_default on the create and delete by deleting all email customizations. Comma separated string with values of 'create' or 'destroy' or both `create,destroy'.",
   withForceIsDefault(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"force_is_default" expected to be of type "string"';
+    assert std.isString(value) : '"force_is_default" expected to be of type "string"';
+
     {
-      force_is_default: converted,
+      force_is_default: value,
     }
   ),
+
   "#withIsDefault":: "Whether the customization is the default",
   withIsDefault(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"is_default" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"is_default" expected to be of type "bool"';
+
     {
-      is_default: converted,
+      is_default: value,
     }
   ),
+
   "#withLanguage":: "The language supported by the customization - Example values from [supported languages](https://developer.okta.com/docs/reference/api/brands/#supported-languages)",
   withLanguage(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"language" expected to be of type "string"';
+    assert std.isString(value) : '"language" expected to be of type "string"';
+
     {
-      language: converted,
+      language: value,
     }
   ),
+
   "#withSubject":: "The subject of the customization",
   withSubject(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"subject" expected to be of type "string"';
+    assert std.isString(value) : '"subject" expected to be of type "string"';
+
     {
-      subject: converted,
+      subject: value,
     }
   ),
+
   "#withTemplateName":: "Template Name - Example values: `AccountLockout`,`ADForgotPassword`,`ADForgotPasswordDenied`,`ADSelfServiceUnlock`,`ADUserActivation`,`AuthenticatorEnrolled`,`AuthenticatorReset`,`ChangeEmailConfirmation`,`EmailChallenge`,`EmailChangeConfirmation`,`EmailFactorVerification`,`ForgotPassword`,`ForgotPasswordDenied`,`IGAReviewerEndNotification`,`IGAReviewerNotification`,`IGAReviewerPendingNotification`,`IGAReviewerReassigned`,`LDAPForgotPassword`,`LDAPForgotPasswordDenied`,`LDAPSelfServiceUnlock`,`LDAPUserActivation`,`MyAccountChangeConfirmation`,`NewSignOnNotification`,`OktaVerifyActivation`,`PasswordChanged`,`PasswordResetByAdmin`,`PendingEmailChange`,`RegistrationActivation`,`RegistrationEmailVerification`,`SelfServiceUnlock`,`SelfServiceUnlockOnUnlockedAccount`,`UserActivation`",
   withTemplateName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"template_name" expected to be of type "string"';
+    assert std.isString(value) : '"template_name" expected to be of type "string"';
+
     {
-      template_name: converted,
+      template_name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_domain.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_domain.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId, displayName, domain, userName):: (
     {
       jsonnetTfMetadata:: {
@@ -16,43 +17,48 @@
     + block.withDomain(domain)
     + block.withUserName(userName)
   ),
+
   "#withBrandId":: "Brand id of the email domain.",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   "#withDisplayName":: "Display name of the email domain.",
   withDisplayName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"display_name" expected to be of type "string"';
+    assert std.isString(value) : '"display_name" expected to be of type "string"';
+
     {
-      display_name: converted,
+      display_name: value,
     }
   ),
+
   "#withDomain":: "Mail domain to send from.",
   withDomain(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"domain" expected to be of type "string"';
+    assert std.isString(value) : '"domain" expected to be of type "string"';
+
     {
-      domain: converted,
+      domain: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withUserName":: "User name of the email domain.",
   withUserName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_name" expected to be of type "string"';
+    assert std.isString(value) : '"user_name" expected to be of type "string"';
+
     {
-      user_name: converted,
+      user_name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_domain_verification.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_domain_verification.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, emailDomainId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,19 +14,21 @@
     }
     + block.withEmailDomainId(emailDomainId)
   ),
+
   "#withEmailDomainId":: "Email domain ID",
   withEmailDomainId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"email_domain_id" expected to be of type "string"';
+    assert std.isString(value) : '"email_domain_id" expected to be of type "string"';
+
     {
-      email_domain_id: converted,
+      email_domain_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_sender.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_sender.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, fromAddress, fromName, subdomain):: (
     {
       jsonnetTfMetadata:: {
@@ -15,35 +16,39 @@
     + block.withFromName(fromName)
     + block.withSubdomain(subdomain)
   ),
+
   "#withFromAddress":: "Email address to send from ",
   withFromAddress(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"from_address" expected to be of type "string"';
+    assert std.isString(value) : '"from_address" expected to be of type "string"';
+
     {
-      from_address: converted,
+      from_address: value,
     }
   ),
+
   "#withFromName":: "Name of sender",
   withFromName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"from_name" expected to be of type "string"';
+    assert std.isString(value) : '"from_name" expected to be of type "string"';
+
     {
-      from_name: converted,
+      from_name: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withSubdomain":: "Mail domain to send from",
   withSubdomain(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"subdomain" expected to be of type "string"';
+    assert std.isString(value) : '"subdomain" expected to be of type "string"';
+
     {
-      subdomain: converted,
+      subdomain: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_sender_verification.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_sender_verification.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, senderId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,19 +14,21 @@
     }
     + block.withSenderId(senderId)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withSenderId":: "Email sender ID",
   withSenderId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"sender_id" expected to be of type "string"';
+    assert std.isString(value) : '"sender_id" expected to be of type "string"';
+
     {
-      sender_id: converted,
+      sender_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_smtp_server.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_smtp_server.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, alias, host, password, port, username):: (
     {
       jsonnetTfMetadata:: {
@@ -17,59 +18,66 @@
     + block.withPort(port)
     + block.withUsername(username)
   ),
+
   "#withAlias":: "Human-readable name for your SMTP server.",
   withAlias(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"alias" expected to be of type "string"';
+    assert std.isString(value) : '"alias" expected to be of type "string"';
+
     {
-      alias: converted,
+      alias: value,
     }
   ),
+
   "#withEnabled":: "If true, routes all email traffic through your SMTP server.",
   withEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"enabled" expected to be of type "bool"';
+
     {
-      enabled: converted,
+      enabled: value,
     }
   ),
+
   "#withHost":: "Hostname or IP address of your SMTP server.",
   withHost(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"host" expected to be of type "string"';
+    assert std.isString(value) : '"host" expected to be of type "string"';
+
     {
-      host: converted,
+      host: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withPassword":: "User name of the email domain.",
   withPassword(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"password" expected to be of type "string"';
+    assert std.isString(value) : '"password" expected to be of type "string"';
+
     {
-      password: converted,
+      password: value,
     }
   ),
+
   "#withPort":: "Port number of your SMTP server.",
   withPort(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"port" expected to be of type "number"';
+    assert std.isNumber(value) : '"port" expected to be of type "number"';
+
     {
-      port: converted,
+      port: value,
     }
   ),
+
   "#withUsername":: "Display name of the email domain.",
   withUsername(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"username" expected to be of type "string"';
+    assert std.isString(value) : '"username" expected to be of type "string"';
+
     {
-      username: converted,
+      username: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_template_settings.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_email_template_settings.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId, recipients, templateName):: (
     {
       jsonnetTfMetadata:: {
@@ -15,28 +16,31 @@
     + block.withRecipients(recipients)
     + block.withTemplateName(templateName)
   ),
+
   "#withBrandId":: "The ID of the brand.",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   "#withRecipients":: "The recipients the emails of this template will be sent to - Valid values: `ALL_USERS`, `ADMINS_ONLY`, `NO_USERS`",
   withRecipients(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"recipients" expected to be of type "string"';
+    assert std.isString(value) : '"recipients" expected to be of type "string"';
+
     {
-      recipients: converted,
+      recipients: value,
     }
   ),
+
   "#withTemplateName":: "Email template name - Example values: `AccountLockout`,`ADForgotPassword`,`ADForgotPasswordDenied`,`ADSelfServiceUnlock`,`ADUserActivation`,`AuthenticatorEnrolled`,`AuthenticatorReset`,`ChangeEmailConfirmation`,`EmailChallenge`,`EmailChangeConfirmation`,`EmailFactorVerification`,`ForgotPassword`,`ForgotPasswordDenied`,`IGAReviewerEndNotification`,`IGAReviewerNotification`,`IGAReviewerPendingNotification`,`IGAReviewerReassigned`,`LDAPForgotPassword`,`LDAPForgotPasswordDenied`,`LDAPSelfServiceUnlock`,`LDAPUserActivation`,`MyAccountChangeConfirmation`,`NewSignOnNotification`,`OktaVerifyActivation`,`PasswordChanged`,`PasswordResetByAdmin`,`PendingEmailChange`,`RegistrationActivation`,`RegistrationEmailVerification`,`SelfServiceUnlock`,`SelfServiceUnlockOnUnlockedAccount`,`UserActivation`",
   withTemplateName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"template_name" expected to be of type "string"';
+    assert std.isString(value) : '"template_name" expected to be of type "string"';
+
     {
-      template_name: converted,
+      template_name: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_event_hook.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_event_hook.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, channel, events, name):: (
     {
       jsonnetTfMetadata:: {
@@ -15,59 +16,68 @@
     + block.withEvents(events)
     + block.withName(name)
   ),
+
   "#withAuth":: "Details of the endpoint the event hook will hit.    \t- 'version' - (Required) The version of the channel. The currently-supported version is '1.0.0'. \t- 'uri' - (Required) The URI the hook will hit. \t- 'type' - (Optional) The type of hook to trigger. Currently, the only supported type is 'HTTP'.",
   withAuth(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"auth" expected to be of type "map"';
+    assert std.isObject(value) : '"auth" expected to be of type "map"';
+
     {
-      auth: converted,
+      auth: value,
     }
   ),
+
   "#withChannel":: "Details of the endpoint the event hook will hit.",
   withChannel(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"channel" expected to be of type "map"';
+    assert std.isObject(value) : '"channel" expected to be of type "map"';
+
     {
-      channel: converted,
+      channel: value,
     }
   ),
+
   "#withEvents":: "The events that will be delivered to this hook. [See here for a list of supported events](https://developer.okta.com/docs/reference/api/event-types/?q=event-hook-eligible).",
   withEvents(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"events" expected to be of type "set"';
+
     {
       events: converted,
     }
   ),
+
   "#withEventsMixin":: "The events that will be delivered to this hook. [See here for a list of supported events](https://developer.okta.com/docs/reference/api/event-types/?q=event-hook-eligible).",
   withEventsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"events" expected to be of type "set"';
+
     {
       events+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "The event hook display name.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withStatus":: "Default to `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
   withTerraformName(value):: {
@@ -77,30 +87,34 @@
       },
     },
   },
+
   headers:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withKey(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"key" expected to be of type "string"';
+      assert std.isString(value) : '"key" expected to be of type "string"';
+
       {
-        key: converted,
+        key: value,
       }
     ),
+
     withValue(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"value" expected to be of type "string"';
+      assert std.isString(value) : '"value" expected to be of type "string"';
+
       {
-        value: converted,
+        value: value,
       }
     ),
   },
   withHeaders(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      headers: value,
+      headers: converted,
     }
   ),
   withHeadersMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_event_hook_verification.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_event_hook_verification.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, eventHookId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,19 +14,21 @@
     }
     + block.withEventHookId(eventHookId)
   ),
+
   "#withEventHookId":: "Event hook ID",
   withEventHookId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"event_hook_id" expected to be of type "string"';
+    assert std.isString(value) : '"event_hook_id" expected to be of type "string"';
+
     {
-      event_hook_id: converted,
+      event_hook_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_factor.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_factor.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, providerId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,27 +14,30 @@
     }
     + block.withProviderId(providerId)
   ),
+
   "#withActive":: "Whether to activate the provider, by default, it is set to `true`.",
   withActive(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"active" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"active" expected to be of type "bool"';
+
     {
-      active: converted,
+      active: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withProviderId":: "The MFA provider name. Allowed values are `duo`, `fido_u2f`, `fido_webauthn`, `google_otp`, `okta_call`, `okta_otp`, `okta_password`, `okta_push`, `okta_question`, `okta_sms`, `okta_email`, `rsa_token`, `symantec_vip`, `yubikey_token`, or `hotp`.",
   withProviderId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"provider_id" expected to be of type "string"';
+    assert std.isString(value) : '"provider_id" expected to be of type "string"';
+
     {
-      provider_id: converted,
+      provider_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_factor_totp.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_factor_totp.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,59 +14,66 @@
     }
     + block.withName(name)
   ),
+
   "#withClockDriftInterval":: "Clock drift interval. This setting allows you to build in tolerance for any drift between the token's current time and the server's current time. Valid values: `3`, `5`, `10`. Default is `3`.",
   withClockDriftInterval(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"clock_drift_interval" expected to be of type "number"';
+    assert std.isNumber(value) : '"clock_drift_interval" expected to be of type "number"';
+
     {
-      clock_drift_interval: converted,
+      clock_drift_interval: value,
     }
   ),
+
   "#withHmacAlgorithm":: "HMAC Algorithm. Valid values: `HMacSHA1`, `HMacSHA256`, `HMacSHA512`. Default is `HMacSHA512`.",
   withHmacAlgorithm(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"hmac_algorithm" expected to be of type "string"';
+    assert std.isString(value) : '"hmac_algorithm" expected to be of type "string"';
+
     {
-      hmac_algorithm: converted,
+      hmac_algorithm: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "The TOTP name.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withOtpLength":: "Length of the password. Default is `6`.",
   withOtpLength(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"otp_length" expected to be of type "number"';
+    assert std.isNumber(value) : '"otp_length" expected to be of type "number"';
+
     {
-      otp_length: converted,
+      otp_length: value,
     }
   ),
+
   "#withSharedSecretEncoding":: "Shared secret encoding. Valid values: `base32`, `base64`, `hexadecimal`. Default is `base32`.",
   withSharedSecretEncoding(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"shared_secret_encoding" expected to be of type "string"';
+    assert std.isString(value) : '"shared_secret_encoding" expected to be of type "string"';
+
     {
-      shared_secret_encoding: converted,
+      shared_secret_encoding: value,
     }
   ),
+
   "#withTimeStep":: "Time step in seconds. Valid values: `15`, `30`, `60`. Default is `15`.",
   withTimeStep(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"time_step" expected to be of type "number"';
+    assert std.isNumber(value) : '"time_step" expected to be of type "number"';
+
     {
-      time_step: converted,
+      time_step: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_feature.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_feature.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, featureId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,28 +14,31 @@
     }
     + block.withFeatureId(featureId)
   ),
+
   "#withFeatureId":: "Okta API for feature only reads and updates therefore the okta_feature resource needs to act as a quasi data source. Do this by setting feature_id",
   withFeatureId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"feature_id" expected to be of type "string"';
+    assert std.isString(value) : '"feature_id" expected to be of type "string"';
+
     {
-      feature_id: converted,
+      feature_id: value,
     }
   ),
+
   "#withLifeCycle":: "Whether to `ENABLE` or `DISABLE` the feature",
   withLifeCycle(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"life_cycle" expected to be of type "string"';
+    assert std.isString(value) : '"life_cycle" expected to be of type "string"';
+
     {
-      life_cycle: converted,
+      life_cycle: value,
     }
   ),
+
   "#withMode":: "Indicates if you want to force enable or disable a feature. Value is `true` meaning force",
   withMode(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"mode" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"mode" expected to be of type "bool"';
+
     {
-      mode: converted,
+      mode: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_group.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_group.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,43 +14,48 @@
     }
     + block.withName(name)
   ),
+
   "#withCustomProfileAttributes":: "JSON formatted custom attributes for a group. It must be JSON due to various types Okta allows.",
   withCustomProfileAttributes(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"custom_profile_attributes" expected to be of type "string"';
+    assert std.isString(value) : '"custom_profile_attributes" expected to be of type "string"';
+
     {
-      custom_profile_attributes: converted,
+      custom_profile_attributes: value,
     }
   ),
+
   "#withDescription":: "The description of the Okta Group.",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "The name of the Okta Group.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withSkipUsers":: "Ignore users sync. This is a temporary solution until 'users' field is supported in all the app-like resources",
   withSkipUsers(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"skip_users" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"skip_users" expected to be of type "bool"';
+
     {
-      skip_users: converted,
+      skip_users: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_group_memberships.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_group_memberships.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, groupId, users):: (
     {
       jsonnetTfMetadata:: {
@@ -14,41 +15,48 @@
     + block.withGroupId(groupId)
     + block.withUsers(users)
   ),
+
   "#withGroupId":: "ID of a Okta group.",
   withGroupId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"group_id" expected to be of type "string"';
+    assert std.isString(value) : '"group_id" expected to be of type "string"';
+
     {
-      group_id: converted,
+      group_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withTrackAllUsers":: "The resource concerns itself with all users added/deleted to the group; even those managed outside of the resource.",
   withTrackAllUsers(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"track_all_users" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"track_all_users" expected to be of type "bool"';
+
     {
-      track_all_users: converted,
+      track_all_users: value,
     }
   ),
+
   "#withUsers":: "The list of Okta user IDs which the group should have membership managed for.",
   withUsers(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users" expected to be of type "set"';
+
     {
       users: converted,
     }
   ),
+
   "#withUsersMixin":: "The list of Okta user IDs which the group should have membership managed for.",
   withUsersMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users" expected to be of type "set"';
+
     {
       users+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_group_owner.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_group_owner.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, groupId, idOfGroupOwner, type):: (
     {
       jsonnetTfMetadata:: {
@@ -15,28 +16,31 @@
     + block.withIdOfGroupOwner(idOfGroupOwner)
     + block.withType(type)
   ),
+
   "#withGroupId":: "The id of the group",
   withGroupId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"group_id" expected to be of type "string"';
+    assert std.isString(value) : '"group_id" expected to be of type "string"';
+
     {
-      group_id: converted,
+      group_id: value,
     }
   ),
+
   "#withIdOfGroupOwner":: "The user id of the group owner",
   withIdOfGroupOwner(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id_of_group_owner" expected to be of type "string"';
+    assert std.isString(value) : '"id_of_group_owner" expected to be of type "string"';
+
     {
-      id_of_group_owner: converted,
+      id_of_group_owner: value,
     }
   ),
+
   "#withType":: "The entity type of the owner. Enum: 'GROUP' 'USER'",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_group_role.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_group_role.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, groupId, roleType):: (
     {
       jsonnetTfMetadata:: {
@@ -14,81 +15,95 @@
     + block.withGroupId(groupId)
     + block.withRoleType(roleType)
   ),
+
   "#withDisableNotifications":: "When this setting is enabled, the admins won't receive any of the default Okta administrator emails. These admins also won't have access to contact Okta Support and open support cases on behalf of your org.",
   withDisableNotifications(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"disable_notifications" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"disable_notifications" expected to be of type "bool"';
+
     {
-      disable_notifications: converted,
+      disable_notifications: value,
     }
   ),
+
   "#withGroupId":: "ID of group to attach admin roles to",
   withGroupId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"group_id" expected to be of type "string"';
+    assert std.isString(value) : '"group_id" expected to be of type "string"';
+
     {
-      group_id: converted,
+      group_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withResourceSetId":: "Resource Set ID. Required for role_type = `CUSTOM`",
   withResourceSetId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"resource_set_id" expected to be of type "string"';
+    assert std.isString(value) : '"resource_set_id" expected to be of type "string"';
+
     {
-      resource_set_id: converted,
+      resource_set_id: value,
     }
   ),
+
   "#withRoleId":: "Role ID. Required for role_type = `CUSTOM`",
   withRoleId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"role_id" expected to be of type "string"';
+    assert std.isString(value) : '"role_id" expected to be of type "string"';
+
     {
-      role_id: converted,
+      role_id: value,
     }
   ),
+
   "#withRoleType":: "Admin role assigned to the group. It can be any one of the following values: \t'API_ADMIN', \t'APP_ADMIN', \t'CUSTOM', \t'GROUP_MEMBERSHIP_ADMIN', \t'HELP_DESK_ADMIN', \t'MOBILE_ADMIN', \t'ORG_ADMIN', \t'READ_ONLY_ADMIN', \t'REPORT_ADMIN', \t'SUPER_ADMIN', \t'USER_ADMIN' \t. See [API Docs](https://developer.okta.com/docs/api/openapi/okta-management/guides/roles/#standard-roles). \t- 'USER_ADMIN' is the Group Administrator.",
   withRoleType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"role_type" expected to be of type "string"';
+    assert std.isString(value) : '"role_type" expected to be of type "string"';
+
     {
-      role_type: converted,
+      role_type: value,
     }
   ),
+
   "#withTargetAppList":: "A list of app names (name represents set of app instances, like 'salesforce' or 'facebook'), or a combination of app name and app instance ID (like 'facebook.0oapsqQ6dv19pqyEo0g3') you would like as the targets of the admin role. - Only supported when used with the role type `APP_ADMIN`.",
   withTargetAppList(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"target_app_list" expected to be of type "set"';
+
     {
       target_app_list: converted,
     }
   ),
+
   "#withTargetAppListMixin":: "A list of app names (name represents set of app instances, like 'salesforce' or 'facebook'), or a combination of app name and app instance ID (like 'facebook.0oapsqQ6dv19pqyEo0g3') you would like as the targets of the admin role. - Only supported when used with the role type `APP_ADMIN`.",
   withTargetAppListMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"target_app_list" expected to be of type "set"';
+
     {
       target_app_list+: converted,
     }
   ),
+
   "#withTargetGroupList":: "A list of group IDs you would like as the targets of the admin role. - Only supported when used with the role types: `GROUP_MEMBERSHIP_ADMIN`, `HELP_DESK_ADMIN`, or `USER_ADMIN`.",
   withTargetGroupList(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"target_group_list" expected to be of type "set"';
+
     {
       target_group_list: converted,
     }
   ),
+
   "#withTargetGroupListMixin":: "A list of group IDs you would like as the targets of the admin role. - Only supported when used with the role types: `GROUP_MEMBERSHIP_ADMIN`, `HELP_DESK_ADMIN`, or `USER_ADMIN`.",
   withTargetGroupListMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"target_group_list" expected to be of type "set"';
+
     {
       target_group_list+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_group_rule.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_group_rule.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, expressionValue, groupAssignments, name):: (
     {
       jsonnetTfMetadata:: {
@@ -15,81 +16,95 @@
     + block.withGroupAssignments(groupAssignments)
     + block.withName(name)
   ),
+
   "#withExpressionType":: "The expression type to use to invoke the rule. The default is `urn:okta:expression:1.0`.",
   withExpressionType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"expression_type" expected to be of type "string"';
+    assert std.isString(value) : '"expression_type" expected to be of type "string"';
+
     {
-      expression_type: converted,
+      expression_type: value,
     }
   ),
+
   "#withExpressionValue":: "The expression value.",
   withExpressionValue(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"expression_value" expected to be of type "string"';
+    assert std.isString(value) : '"expression_value" expected to be of type "string"';
+
     {
-      expression_value: converted,
+      expression_value: value,
     }
   ),
+
   "#withGroupAssignments":: "The list of group ids to assign the users to.",
   withGroupAssignments(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"group_assignments" expected to be of type "set"';
+
     {
       group_assignments: converted,
     }
   ),
+
   "#withGroupAssignmentsMixin":: "The list of group ids to assign the users to.",
   withGroupAssignmentsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"group_assignments" expected to be of type "set"';
+
     {
       group_assignments+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "The name of the Group Rule (min character 1; max characters 50).",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withRemoveAssignedUsers":: "Remove users added by this rule from the assigned group after deleting this resource. Default is `false`",
   withRemoveAssignedUsers(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"remove_assigned_users" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"remove_assigned_users" expected to be of type "bool"';
+
     {
-      remove_assigned_users: converted,
+      remove_assigned_users: value,
     }
   ),
+
   "#withStatus":: "Default to `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withUsersExcluded":: "The list of user IDs that would be excluded when rules are processed",
   withUsersExcluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users_excluded" expected to be of type "set"';
+
     {
       users_excluded: converted,
     }
   ),
+
   "#withUsersExcludedMixin":: "The list of user IDs that would be excluded when rules are processed",
   withUsersExcludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users_excluded" expected to be of type "set"';
+
     {
       users_excluded+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_group_schema_property.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_group_schema_property.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, index, title, type):: (
     {
       jsonnetTfMetadata:: {
@@ -15,154 +16,177 @@
     + block.withTitle(title)
     + block.withType(type)
   ),
+
   "#withArrayEnum":: "Array of values that an array property's items can be set to.",
   withArrayEnum(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"array_enum" expected to be of type "list"';
+
     {
       array_enum: converted,
     }
   ),
+
   "#withArrayEnumMixin":: "Array of values that an array property's items can be set to.",
   withArrayEnumMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"array_enum" expected to be of type "list"';
+
     {
       array_enum+: converted,
     }
   ),
+
   "#withArrayType":: "The type of the array elements if `type` is set to `array`",
   withArrayType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"array_type" expected to be of type "string"';
+    assert std.isString(value) : '"array_type" expected to be of type "string"';
+
     {
-      array_type: converted,
+      array_type: value,
     }
   ),
+
   "#withDescription":: "The description of the user schema property.",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   "#withEnum":: "Array of values a primitive property can be set to. See `array_enum` for arrays.",
   withEnum(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"enum" expected to be of type "list"';
+
     {
       enum: converted,
     }
   ),
+
   "#withEnumMixin":: "Array of values a primitive property can be set to. See `array_enum` for arrays.",
   withEnumMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"enum" expected to be of type "list"';
+
     {
       enum+: converted,
     }
   ),
+
   "#withExternalName":: "External name of the user schema property.",
   withExternalName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"external_name" expected to be of type "string"';
+    assert std.isString(value) : '"external_name" expected to be of type "string"';
+
     {
-      external_name: converted,
+      external_name: value,
     }
   ),
+
   "#withExternalNamespace":: "External namespace of the user schema property.",
   withExternalNamespace(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"external_namespace" expected to be of type "string"';
+    assert std.isString(value) : '"external_namespace" expected to be of type "string"';
+
     {
-      external_namespace: converted,
+      external_namespace: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIndex":: "Subschema unique string identifier",
   withIndex(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"index" expected to be of type "string"';
+    assert std.isString(value) : '"index" expected to be of type "string"';
+
     {
-      index: converted,
+      index: value,
     }
   ),
+
   "#withMaster":: "Master priority for the group schema property. It can be set to `PROFILE_MASTER`, `OVERRIDE` or `OKTA`. Default: `PROFILE_MASTER`",
   withMaster(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"master" expected to be of type "string"';
+    assert std.isString(value) : '"master" expected to be of type "string"';
+
     {
-      master: converted,
+      master: value,
     }
   ),
+
   "#withMaxLength":: "The maximum length of the user property value. Only applies to type `string`",
   withMaxLength(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"max_length" expected to be of type "number"';
+    assert std.isNumber(value) : '"max_length" expected to be of type "number"';
+
     {
-      max_length: converted,
+      max_length: value,
     }
   ),
+
   "#withMinLength":: "The minimum length of the user property value. Only applies to type `string`",
   withMinLength(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"min_length" expected to be of type "number"';
+    assert std.isNumber(value) : '"min_length" expected to be of type "number"';
+
     {
-      min_length: converted,
+      min_length: value,
     }
   ),
+
   "#withPermissions":: "Access control permissions for the property. It can be set to `READ_WRITE`, `READ_ONLY`, `HIDE`. Default: `READ_ONLY`",
   withPermissions(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"permissions" expected to be of type "string"';
+    assert std.isString(value) : '"permissions" expected to be of type "string"';
+
     {
-      permissions: converted,
+      permissions: value,
     }
   ),
+
   "#withRequired":: "Whether the subschema is required",
   withRequired(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"required" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"required" expected to be of type "bool"';
+
     {
-      required: converted,
+      required: value,
     }
   ),
+
   withScope(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"scope" expected to be of type "string"';
+    assert std.isString(value) : '"scope" expected to be of type "string"';
+
     {
-      scope: converted,
+      scope: value,
     }
   ),
+
   "#withTitle":: "Subschema title (display name)",
   withTitle(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"title" expected to be of type "string"';
+    assert std.isString(value) : '"title" expected to be of type "string"';
+
     {
-      title: converted,
+      title: value,
     }
   ),
+
   "#withType":: "The type of the schema property. It can be `string`, `boolean`, `number`, `integer`, `array`, or `object`",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
+
   "#withUnique":: "Whether the property should be unique. It can be set to `UNIQUE_VALIDATED` or `NOT_UNIQUE`.",
   withUnique(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"unique" expected to be of type "string"';
+    assert std.isString(value) : '"unique" expected to be of type "string"';
+
     {
-      unique: converted,
+      unique: value,
     }
   ),
   withTerraformName(value):: {
@@ -172,91 +196,101 @@
       },
     },
   },
+
   arrayOneOf:: {
     local block = self,
+
     new(const, title):: (
       {}
       + block.withConst(const)
       + block.withTitle(title)
     ),
+
     "#withConst":: "Value mapping to member of `array_enum`",
     withConst(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"const" expected to be of type "string"';
+      assert std.isString(value) : '"const" expected to be of type "string"';
+
       {
-        const: converted,
+        const: value,
       }
     ),
+
     "#withTitle":: "Display name for the enum value.",
     withTitle(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"title" expected to be of type "string"';
+      assert std.isString(value) : '"title" expected to be of type "string"';
+
       {
-        title: converted,
+        title: value,
       }
     ),
   },
   masterOverridePriority:: {
     local block = self,
+
     new(value):: (
       {}
       + block.withValue(value)
     ),
+
     withType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"type" expected to be of type "string"';
+      assert std.isString(value) : '"type" expected to be of type "string"';
+
       {
-        type: converted,
+        type: value,
       }
     ),
+
     withValue(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"value" expected to be of type "string"';
+      assert std.isString(value) : '"value" expected to be of type "string"';
+
       {
-        value: converted,
+        value: value,
       }
     ),
   },
   oneOf:: {
     local block = self,
+
     new(const, title):: (
       {}
       + block.withConst(const)
       + block.withTitle(title)
     ),
+
     "#withConst":: "Enum value",
     withConst(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"const" expected to be of type "string"';
+      assert std.isString(value) : '"const" expected to be of type "string"';
+
       {
-        const: converted,
+        const: value,
       }
     ),
+
     "#withTitle":: "Enum title",
     withTitle(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"title" expected to be of type "string"';
+      assert std.isString(value) : '"title" expected to be of type "string"';
+
       {
-        title: converted,
+        title: value,
       }
     ),
   },
   withArrayOneOf(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      array_one_of: value,
+      array_one_of: converted,
     }
   ),
   withMasterOverridePriority(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      master_override_priority: value,
+      master_override_priority: converted,
     }
   ),
   withOneOf(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      one_of: value,
+      one_of: converted,
     }
   ),
   withArrayOneOfMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_idp_oidc.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_idp_oidc.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, authorizationBinding, authorizationUrl, clientId, clientSecret, issuerUrl, jwksBinding, jwksUrl, name, scopes, tokenBinding, tokenUrl):: (
     {
       jsonnetTfMetadata:: {
@@ -23,314 +24,361 @@
     + block.withTokenBinding(tokenBinding)
     + block.withTokenUrl(tokenUrl)
   ),
+
   "#withAccountLinkAction":: "Specifies the account linking action for an IdP user. Default: `AUTO`",
   withAccountLinkAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"account_link_action" expected to be of type "string"';
+    assert std.isString(value) : '"account_link_action" expected to be of type "string"';
+
     {
-      account_link_action: converted,
+      account_link_action: value,
     }
   ),
+
   "#withAccountLinkGroupInclude":: "Group memberships to determine link candidates.",
   withAccountLinkGroupInclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"account_link_group_include" expected to be of type "set"';
+
     {
       account_link_group_include: converted,
     }
   ),
+
   "#withAccountLinkGroupIncludeMixin":: "Group memberships to determine link candidates.",
   withAccountLinkGroupIncludeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"account_link_group_include" expected to be of type "set"';
+
     {
       account_link_group_include+: converted,
     }
   ),
+
   "#withAuthorizationBinding":: "The method of making an authorization request. It can be set to `HTTP-POST` or `HTTP-REDIRECT`.",
   withAuthorizationBinding(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"authorization_binding" expected to be of type "string"';
+    assert std.isString(value) : '"authorization_binding" expected to be of type "string"';
+
     {
-      authorization_binding: converted,
+      authorization_binding: value,
     }
   ),
+
   "#withAuthorizationUrl":: "IdP Authorization Server (AS) endpoint to request consent from the user and obtain an authorization code grant.",
   withAuthorizationUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"authorization_url" expected to be of type "string"';
+    assert std.isString(value) : '"authorization_url" expected to be of type "string"';
+
     {
-      authorization_url: converted,
+      authorization_url: value,
     }
   ),
+
   "#withClientId":: "Unique identifier issued by AS for the Okta IdP instance.",
   withClientId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"client_id" expected to be of type "string"';
+    assert std.isString(value) : '"client_id" expected to be of type "string"';
+
     {
-      client_id: converted,
+      client_id: value,
     }
   ),
+
   "#withClientSecret":: "Client secret issued by AS for the Okta IdP instance.",
   withClientSecret(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"client_secret" expected to be of type "string"';
+    assert std.isString(value) : '"client_secret" expected to be of type "string"';
+
     {
-      client_secret: converted,
+      client_secret: value,
     }
   ),
+
   "#withDeprovisionedAction":: "Action for a previously deprovisioned IdP user during authentication. Can be `NONE` or `REACTIVATE`. Default: `NONE`",
   withDeprovisionedAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"deprovisioned_action" expected to be of type "string"';
+    assert std.isString(value) : '"deprovisioned_action" expected to be of type "string"';
+
     {
-      deprovisioned_action: converted,
+      deprovisioned_action: value,
     }
   ),
+
   "#withFilter":: "Optional regular expression pattern used to filter untrusted IdP usernames.",
   withFilter(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"filter" expected to be of type "string"';
+    assert std.isString(value) : '"filter" expected to be of type "string"';
+
     {
-      filter: converted,
+      filter: value,
     }
   ),
+
   "#withGroupsAction":: "Provisioning action for IdP user's group memberships. It can be `NONE`, `SYNC`, `APPEND`, or `ASSIGN`. Default: `NONE`",
   withGroupsAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"groups_action" expected to be of type "string"';
+    assert std.isString(value) : '"groups_action" expected to be of type "string"';
+
     {
-      groups_action: converted,
+      groups_action: value,
     }
   ),
+
   "#withGroupsAssignment":: "List of Okta Group IDs to add an IdP user as a member with the `ASSIGN` `groups_action`.",
   withGroupsAssignment(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_assignment" expected to be of type "set"';
+
     {
       groups_assignment: converted,
     }
   ),
+
   "#withGroupsAssignmentMixin":: "List of Okta Group IDs to add an IdP user as a member with the `ASSIGN` `groups_action`.",
   withGroupsAssignmentMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_assignment" expected to be of type "set"';
+
     {
       groups_assignment+: converted,
     }
   ),
+
   "#withGroupsAttribute":: "IdP user profile attribute name (case-insensitive) for an array value that contains group memberships.",
   withGroupsAttribute(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"groups_attribute" expected to be of type "string"';
+    assert std.isString(value) : '"groups_attribute" expected to be of type "string"';
+
     {
-      groups_attribute: converted,
+      groups_attribute: value,
     }
   ),
+
   "#withGroupsFilter":: "Whitelist of Okta Group identifiers that are allowed for the `APPEND` or `SYNC` `groups_action`.",
   withGroupsFilter(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_filter" expected to be of type "set"';
+
     {
       groups_filter: converted,
     }
   ),
+
   "#withGroupsFilterMixin":: "Whitelist of Okta Group identifiers that are allowed for the `APPEND` or `SYNC` `groups_action`.",
   withGroupsFilterMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_filter" expected to be of type "set"';
+
     {
       groups_filter+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIssuerMode":: "Indicates whether Okta uses the original Okta org domain URL, a custom domain URL, or dynamic. It can be `ORG_URL`, `CUSTOM_URL`, or `DYNAMIC`. Default: `ORG_URL`",
   withIssuerMode(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"issuer_mode" expected to be of type "string"';
+    assert std.isString(value) : '"issuer_mode" expected to be of type "string"';
+
     {
-      issuer_mode: converted,
+      issuer_mode: value,
     }
   ),
+
   "#withIssuerUrl":: "URI that identifies the issuer.",
   withIssuerUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"issuer_url" expected to be of type "string"';
+    assert std.isString(value) : '"issuer_url" expected to be of type "string"';
+
     {
-      issuer_url: converted,
+      issuer_url: value,
     }
   ),
+
   "#withJwksBinding":: "The method of making a request for the OIDC JWKS. It can be set to `HTTP-POST` or `HTTP-REDIRECT`",
   withJwksBinding(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"jwks_binding" expected to be of type "string"';
+    assert std.isString(value) : '"jwks_binding" expected to be of type "string"';
+
     {
-      jwks_binding: converted,
+      jwks_binding: value,
     }
   ),
+
   "#withJwksUrl":: "Endpoint where the keys signer publishes its keys in a JWK Set.",
   withJwksUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"jwks_url" expected to be of type "string"';
+    assert std.isString(value) : '"jwks_url" expected to be of type "string"';
+
     {
-      jwks_url: converted,
+      jwks_url: value,
     }
   ),
+
   "#withMaxClockSkew":: "Maximum allowable clock-skew when processing messages from the IdP.",
   withMaxClockSkew(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"max_clock_skew" expected to be of type "number"';
+    assert std.isNumber(value) : '"max_clock_skew" expected to be of type "number"';
+
     {
-      max_clock_skew: converted,
+      max_clock_skew: value,
     }
   ),
+
   "#withName":: "Name of the IdP",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withPkceRequired":: "Require Proof Key for Code Exchange (PKCE) for additional verification key rotation mode. See: https://developer.okta.com/docs/reference/api/idps/#oauth-2-0-and-openid-connect-client-object",
   withPkceRequired(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"pkce_required" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"pkce_required" expected to be of type "bool"';
+
     {
-      pkce_required: converted,
+      pkce_required: value,
     }
   ),
+
   "#withProfileMaster":: "Determines if the IdP should act as a source of truth for user profile attributes.",
   withProfileMaster(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"profile_master" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"profile_master" expected to be of type "bool"';
+
     {
-      profile_master: converted,
+      profile_master: value,
     }
   ),
+
   "#withProtocolType":: " The type of protocol to use. It can be `OIDC` or `OAUTH2`. Default: `OIDC`",
   withProtocolType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"protocol_type" expected to be of type "string"';
+    assert std.isString(value) : '"protocol_type" expected to be of type "string"';
+
     {
-      protocol_type: converted,
+      protocol_type: value,
     }
   ),
+
   "#withProvisioningAction":: "Provisioning action for an IdP user during authentication. Default: `AUTO`",
   withProvisioningAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"provisioning_action" expected to be of type "string"';
+    assert std.isString(value) : '"provisioning_action" expected to be of type "string"';
+
     {
-      provisioning_action: converted,
+      provisioning_action: value,
     }
   ),
+
   "#withRequestSignatureAlgorithm":: "The HMAC Signature Algorithm used when signing an authorization request. Defaults to `HS256`. It can be `HS256`, `HS384`, `HS512`, `SHA-256`. `RS256`, `RS384`, or `RS512`. NOTE: `SHA-256` an undocumented legacy value and not continue to be valid. See API docs https://developer.okta.com/docs/reference/api/idps/#oidc-request-signature-algorithm-object",
   withRequestSignatureAlgorithm(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"request_signature_algorithm" expected to be of type "string"';
+    assert std.isString(value) : '"request_signature_algorithm" expected to be of type "string"';
+
     {
-      request_signature_algorithm: converted,
+      request_signature_algorithm: value,
     }
   ),
+
   "#withRequestSignatureScope":: "Specifies whether to digitally sign an AuthnRequest messages to the IdP. Defaults to `REQUEST`. It can be `REQUEST` or `NONE`.",
   withRequestSignatureScope(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"request_signature_scope" expected to be of type "string"';
+    assert std.isString(value) : '"request_signature_scope" expected to be of type "string"';
+
     {
-      request_signature_scope: converted,
+      request_signature_scope: value,
     }
   ),
+
   "#withScopes":: "The scopes of the IdP.",
   withScopes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"scopes" expected to be of type "set"';
+
     {
       scopes: converted,
     }
   ),
+
   "#withScopesMixin":: "The scopes of the IdP.",
   withScopesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"scopes" expected to be of type "set"';
+
     {
       scopes+: converted,
     }
   ),
+
   "#withStatus":: "Default to `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withSubjectMatchAttribute":: "Okta user profile attribute for matching transformed IdP username. Only for matchType `CUSTOM_ATTRIBUTE`.",
   withSubjectMatchAttribute(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"subject_match_attribute" expected to be of type "string"';
+    assert std.isString(value) : '"subject_match_attribute" expected to be of type "string"';
+
     {
-      subject_match_attribute: converted,
+      subject_match_attribute: value,
     }
   ),
+
   "#withSubjectMatchType":: "Determines the Okta user profile attribute match conditions for account linking and authentication of the transformed IdP username. By default, it is set to `USERNAME`. It can be set to `USERNAME`, `EMAIL`, `USERNAME_OR_EMAIL` or `CUSTOM_ATTRIBUTE`.",
   withSubjectMatchType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"subject_match_type" expected to be of type "string"';
+    assert std.isString(value) : '"subject_match_type" expected to be of type "string"';
+
     {
-      subject_match_type: converted,
+      subject_match_type: value,
     }
   ),
+
   "#withSuspendedAction":: "Action for a previously suspended IdP user during authentication. Can be `NONE` or `REACTIVATE`. Default: `NONE`",
   withSuspendedAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"suspended_action" expected to be of type "string"';
+    assert std.isString(value) : '"suspended_action" expected to be of type "string"';
+
     {
-      suspended_action: converted,
+      suspended_action: value,
     }
   ),
+
   "#withTokenBinding":: "The method of making a token request. It can be set to `HTTP-POST` or `HTTP-REDIRECT`.",
   withTokenBinding(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"token_binding" expected to be of type "string"';
+    assert std.isString(value) : '"token_binding" expected to be of type "string"';
+
     {
-      token_binding: converted,
+      token_binding: value,
     }
   ),
+
   "#withTokenUrl":: "IdP Authorization Server (AS) endpoint to exchange the authorization code grant for an access token.",
   withTokenUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"token_url" expected to be of type "string"';
+    assert std.isString(value) : '"token_url" expected to be of type "string"';
+
     {
-      token_url: converted,
+      token_url: value,
     }
   ),
+
   withUserInfoBinding(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_info_binding" expected to be of type "string"';
+    assert std.isString(value) : '"user_info_binding" expected to be of type "string"';
+
     {
-      user_info_binding: converted,
+      user_info_binding: value,
     }
   ),
+
   "#withUserInfoUrl":: "Protected resource endpoint that returns claims about the authenticated user.",
   withUserInfoUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_info_url" expected to be of type "string"';
+    assert std.isString(value) : '"user_info_url" expected to be of type "string"';
+
     {
-      user_info_url: converted,
+      user_info_url: value,
     }
   ),
+
   "#withUsernameTemplate":: "Okta EL Expression to generate or transform a unique username for the IdP user. Default: `idpuser.email`",
   withUsernameTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"username_template" expected to be of type "string"';
+    assert std.isString(value) : '"username_template" expected to be of type "string"';
+
     {
-      username_template: converted,
+      username_template: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_idp_saml.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_idp_saml.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, issuer, kid, name, ssoUrl):: (
     {
       jsonnetTfMetadata:: {
@@ -16,291 +17,335 @@
     + block.withName(name)
     + block.withSsoUrl(ssoUrl)
   ),
+
   "#withAccountLinkAction":: "Specifies the account linking action for an IdP user. Default: `AUTO`",
   withAccountLinkAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"account_link_action" expected to be of type "string"';
+    assert std.isString(value) : '"account_link_action" expected to be of type "string"';
+
     {
-      account_link_action: converted,
+      account_link_action: value,
     }
   ),
+
   "#withAccountLinkGroupInclude":: "Group memberships to determine link candidates.",
   withAccountLinkGroupInclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"account_link_group_include" expected to be of type "set"';
+
     {
       account_link_group_include: converted,
     }
   ),
+
   "#withAccountLinkGroupIncludeMixin":: "Group memberships to determine link candidates.",
   withAccountLinkGroupIncludeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"account_link_group_include" expected to be of type "set"';
+
     {
       account_link_group_include+: converted,
     }
   ),
+
   "#withAcsType":: "The type of ACS. It can be `INSTANCE` or `ORG`. Default: `INSTANCE`",
   withAcsType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"acs_type" expected to be of type "string"';
+    assert std.isString(value) : '"acs_type" expected to be of type "string"';
+
     {
-      acs_type: converted,
+      acs_type: value,
     }
   ),
+
   "#withDeprovisionedAction":: "Action for a previously deprovisioned IdP user during authentication. Can be `NONE` or `REACTIVATE`. Default: `NONE`",
   withDeprovisionedAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"deprovisioned_action" expected to be of type "string"';
+    assert std.isString(value) : '"deprovisioned_action" expected to be of type "string"';
+
     {
-      deprovisioned_action: converted,
+      deprovisioned_action: value,
     }
   ),
+
   "#withGroupsAction":: "Provisioning action for IdP user's group memberships. It can be `NONE`, `SYNC`, `APPEND`, or `ASSIGN`. Default: `NONE`",
   withGroupsAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"groups_action" expected to be of type "string"';
+    assert std.isString(value) : '"groups_action" expected to be of type "string"';
+
     {
-      groups_action: converted,
+      groups_action: value,
     }
   ),
+
   "#withGroupsAssignment":: "List of Okta Group IDs to add an IdP user as a member with the `ASSIGN` `groups_action`.",
   withGroupsAssignment(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_assignment" expected to be of type "set"';
+
     {
       groups_assignment: converted,
     }
   ),
+
   "#withGroupsAssignmentMixin":: "List of Okta Group IDs to add an IdP user as a member with the `ASSIGN` `groups_action`.",
   withGroupsAssignmentMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_assignment" expected to be of type "set"';
+
     {
       groups_assignment+: converted,
     }
   ),
+
   "#withGroupsAttribute":: "IdP user profile attribute name (case-insensitive) for an array value that contains group memberships.",
   withGroupsAttribute(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"groups_attribute" expected to be of type "string"';
+    assert std.isString(value) : '"groups_attribute" expected to be of type "string"';
+
     {
-      groups_attribute: converted,
+      groups_attribute: value,
     }
   ),
+
   "#withGroupsFilter":: "Whitelist of Okta Group identifiers that are allowed for the `APPEND` or `SYNC` `groups_action`.",
   withGroupsFilter(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_filter" expected to be of type "set"';
+
     {
       groups_filter: converted,
     }
   ),
+
   "#withGroupsFilterMixin":: "Whitelist of Okta Group identifiers that are allowed for the `APPEND` or `SYNC` `groups_action`.",
   withGroupsFilterMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_filter" expected to be of type "set"';
+
     {
       groups_filter+: converted,
     }
   ),
+
   "#withHonorPersistentNameId":: "Determines if the IdP should persist account linking when the incoming assertion NameID format is urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
   withHonorPersistentNameId(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"honor_persistent_name_id" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"honor_persistent_name_id" expected to be of type "bool"';
+
     {
-      honor_persistent_name_id: converted,
+      honor_persistent_name_id: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIssuer":: "URI that identifies the issuer.",
   withIssuer(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"issuer" expected to be of type "string"';
+    assert std.isString(value) : '"issuer" expected to be of type "string"';
+
     {
-      issuer: converted,
+      issuer: value,
     }
   ),
+
   "#withIssuerMode":: "Indicates whether Okta uses the original Okta org domain URL, or a custom domain URL",
   withIssuerMode(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"issuer_mode" expected to be of type "string"';
+    assert std.isString(value) : '"issuer_mode" expected to be of type "string"';
+
     {
-      issuer_mode: converted,
+      issuer_mode: value,
     }
   ),
+
   "#withKid":: "The ID of the signing key.",
   withKid(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"kid" expected to be of type "string"';
+    assert std.isString(value) : '"kid" expected to be of type "string"';
+
     {
-      kid: converted,
+      kid: value,
     }
   ),
+
   "#withMaxClockSkew":: "Maximum allowable clock-skew when processing messages from the IdP.",
   withMaxClockSkew(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"max_clock_skew" expected to be of type "number"';
+    assert std.isNumber(value) : '"max_clock_skew" expected to be of type "number"';
+
     {
-      max_clock_skew: converted,
+      max_clock_skew: value,
     }
   ),
+
   "#withName":: "Name of the IdP",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withNameFormat":: "The name identifier format to use. By default `urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified`.",
   withNameFormat(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name_format" expected to be of type "string"';
+    assert std.isString(value) : '"name_format" expected to be of type "string"';
+
     {
-      name_format: converted,
+      name_format: value,
     }
   ),
+
   "#withProfileMaster":: "Determines if the IdP should act as a source of truth for user profile attributes.",
   withProfileMaster(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"profile_master" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"profile_master" expected to be of type "bool"';
+
     {
-      profile_master: converted,
+      profile_master: value,
     }
   ),
+
   "#withProvisioningAction":: "Provisioning action for an IdP user during authentication. Default: `AUTO`",
   withProvisioningAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"provisioning_action" expected to be of type "string"';
+    assert std.isString(value) : '"provisioning_action" expected to be of type "string"';
+
     {
-      provisioning_action: converted,
+      provisioning_action: value,
     }
   ),
+
   "#withRequestSignatureAlgorithm":: "The XML digital Signature Algorithm used when signing an `AuthnRequest` message. It can be `SHA-256` or `SHA-1`. Default: `SHA-256`",
   withRequestSignatureAlgorithm(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"request_signature_algorithm" expected to be of type "string"';
+    assert std.isString(value) : '"request_signature_algorithm" expected to be of type "string"';
+
     {
-      request_signature_algorithm: converted,
+      request_signature_algorithm: value,
     }
   ),
+
   "#withRequestSignatureScope":: "Specifies whether to digitally sign an AuthnRequest messages to the IdP. It can be `REQUEST` or `NONE`. Default: `REQUEST`",
   withRequestSignatureScope(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"request_signature_scope" expected to be of type "string"';
+    assert std.isString(value) : '"request_signature_scope" expected to be of type "string"';
+
     {
-      request_signature_scope: converted,
+      request_signature_scope: value,
     }
   ),
+
   "#withResponseSignatureAlgorithm":: "The minimum XML digital signature algorithm allowed when verifying a `SAMLResponse` message or Assertion element. It can be `SHA-256` or `SHA-1`. Default: `SHA-256`",
   withResponseSignatureAlgorithm(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"response_signature_algorithm" expected to be of type "string"';
+    assert std.isString(value) : '"response_signature_algorithm" expected to be of type "string"';
+
     {
-      response_signature_algorithm: converted,
+      response_signature_algorithm: value,
     }
   ),
+
   "#withResponseSignatureScope":: "Specifies whether to verify a `SAMLResponse` message or Assertion element XML digital signature. It can be `RESPONSE`, `ASSERTION`, or `ANY`. Default: `ANY`",
   withResponseSignatureScope(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"response_signature_scope" expected to be of type "string"';
+    assert std.isString(value) : '"response_signature_scope" expected to be of type "string"';
+
     {
-      response_signature_scope: converted,
+      response_signature_scope: value,
     }
   ),
+
   "#withSsoBinding":: "The method of making an SSO request. It can be set to `HTTP-POST` or `HTTP-REDIRECT`. Default: `HTTP-POST`",
   withSsoBinding(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"sso_binding" expected to be of type "string"';
+    assert std.isString(value) : '"sso_binding" expected to be of type "string"';
+
     {
-      sso_binding: converted,
+      sso_binding: value,
     }
   ),
+
   "#withSsoDestination":: "URI reference indicating the address to which the AuthnRequest message is sent.",
   withSsoDestination(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"sso_destination" expected to be of type "string"';
+    assert std.isString(value) : '"sso_destination" expected to be of type "string"';
+
     {
-      sso_destination: converted,
+      sso_destination: value,
     }
   ),
+
   "#withSsoUrl":: "URL of binding-specific endpoint to send an AuthnRequest message to IdP.",
   withSsoUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"sso_url" expected to be of type "string"';
+    assert std.isString(value) : '"sso_url" expected to be of type "string"';
+
     {
-      sso_url: converted,
+      sso_url: value,
     }
   ),
+
   "#withStatus":: "Default to `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withSubjectFilter":: "Optional regular expression pattern used to filter untrusted IdP usernames.",
   withSubjectFilter(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"subject_filter" expected to be of type "string"';
+    assert std.isString(value) : '"subject_filter" expected to be of type "string"';
+
     {
-      subject_filter: converted,
+      subject_filter: value,
     }
   ),
+
   "#withSubjectFormat":: "The name format.",
   withSubjectFormat(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"subject_format" expected to be of type "set"';
+
     {
       subject_format: converted,
     }
   ),
+
   "#withSubjectFormatMixin":: "The name format.",
   withSubjectFormatMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"subject_format" expected to be of type "set"';
+
     {
       subject_format+: converted,
     }
   ),
+
   "#withSubjectMatchAttribute":: "Okta user profile attribute for matching transformed IdP username. Only for matchType `CUSTOM_ATTRIBUTE`.",
   withSubjectMatchAttribute(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"subject_match_attribute" expected to be of type "string"';
+    assert std.isString(value) : '"subject_match_attribute" expected to be of type "string"';
+
     {
-      subject_match_attribute: converted,
+      subject_match_attribute: value,
     }
   ),
+
   "#withSubjectMatchType":: "Determines the Okta user profile attribute match conditions for account linking and authentication of the transformed IdP username. By default, it is set to `USERNAME`. It can be set to `USERNAME`, `EMAIL`, `USERNAME_OR_EMAIL` or `CUSTOM_ATTRIBUTE`.",
   withSubjectMatchType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"subject_match_type" expected to be of type "string"';
+    assert std.isString(value) : '"subject_match_type" expected to be of type "string"';
+
     {
-      subject_match_type: converted,
+      subject_match_type: value,
     }
   ),
+
   "#withSuspendedAction":: "Action for a previously suspended IdP user during authentication. Can be `NONE` or `REACTIVATE`. Default: `NONE`",
   withSuspendedAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"suspended_action" expected to be of type "string"';
+    assert std.isString(value) : '"suspended_action" expected to be of type "string"';
+
     {
-      suspended_action: converted,
+      suspended_action: value,
     }
   ),
+
   "#withUsernameTemplate":: "Okta EL Expression to generate or transform a unique username for the IdP user. Default: `idpuser.email`",
   withUsernameTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"username_template" expected to be of type "string"';
+    assert std.isString(value) : '"username_template" expected to be of type "string"';
+
     {
-      username_template: converted,
+      username_template: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_idp_saml_key.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_idp_saml_key.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, x5c):: (
     {
       jsonnetTfMetadata:: {
@@ -13,25 +14,30 @@
     }
     + block.withX5c(x5c)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withX5c":: "base64-encoded X.509 certificate chain with DER encoding",
   withX5c(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"x5c" expected to be of type "set"';
+
     {
       x5c: converted,
     }
   ),
+
   "#withX5cMixin":: "base64-encoded X.509 certificate chain with DER encoding",
   withX5cMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"x5c" expected to be of type "set"';
+
     {
       x5c+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_idp_social.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_idp_social.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name, scopes, type):: (
     {
       jsonnetTfMetadata:: {
@@ -15,243 +16,281 @@
     + block.withScopes(scopes)
     + block.withType(type)
   ),
+
   "#withAccountLinkAction":: "Specifies the account linking action for an IdP user. Default: `AUTO`",
   withAccountLinkAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"account_link_action" expected to be of type "string"';
+    assert std.isString(value) : '"account_link_action" expected to be of type "string"';
+
     {
-      account_link_action: converted,
+      account_link_action: value,
     }
   ),
+
   "#withAccountLinkGroupInclude":: "Group memberships to determine link candidates.",
   withAccountLinkGroupInclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"account_link_group_include" expected to be of type "set"';
+
     {
       account_link_group_include: converted,
     }
   ),
+
   "#withAccountLinkGroupIncludeMixin":: "Group memberships to determine link candidates.",
   withAccountLinkGroupIncludeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"account_link_group_include" expected to be of type "set"';
+
     {
       account_link_group_include+: converted,
     }
   ),
+
   "#withAppleKid":: "The Key ID that you obtained from Apple when you created the private key for the client",
   withAppleKid(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"apple_kid" expected to be of type "string"';
+    assert std.isString(value) : '"apple_kid" expected to be of type "string"';
+
     {
-      apple_kid: converted,
+      apple_kid: value,
     }
   ),
+
   "#withApplePrivateKey":: "The Key ID that you obtained from Apple when you created the private key for the client. PrivateKey is required when resource is first created. For all consecutive updates, it can be empty/omitted and keeps the existing value if it is empty/omitted. PrivateKey isn't returned when importing this resource.",
   withApplePrivateKey(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"apple_private_key" expected to be of type "string"';
+    assert std.isString(value) : '"apple_private_key" expected to be of type "string"';
+
     {
-      apple_private_key: converted,
+      apple_private_key: value,
     }
   ),
+
   "#withAppleTeamId":: "The Team ID associated with your Apple developer account",
   withAppleTeamId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"apple_team_id" expected to be of type "string"';
+    assert std.isString(value) : '"apple_team_id" expected to be of type "string"';
+
     {
-      apple_team_id: converted,
+      apple_team_id: value,
     }
   ),
+
   "#withClientId":: "Unique identifier issued by AS for the Okta IdP instance.",
   withClientId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"client_id" expected to be of type "string"';
+    assert std.isString(value) : '"client_id" expected to be of type "string"';
+
     {
-      client_id: converted,
+      client_id: value,
     }
   ),
+
   "#withClientSecret":: "Client secret issued by AS for the Okta IdP instance.",
   withClientSecret(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"client_secret" expected to be of type "string"';
+    assert std.isString(value) : '"client_secret" expected to be of type "string"';
+
     {
-      client_secret: converted,
+      client_secret: value,
     }
   ),
+
   "#withDeprovisionedAction":: "Action for a previously deprovisioned IdP user during authentication. Can be `NONE` or `REACTIVATE`. Default: `NONE`",
   withDeprovisionedAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"deprovisioned_action" expected to be of type "string"';
+    assert std.isString(value) : '"deprovisioned_action" expected to be of type "string"';
+
     {
-      deprovisioned_action: converted,
+      deprovisioned_action: value,
     }
   ),
+
   "#withGroupsAction":: "Provisioning action for IdP user's group memberships. It can be `NONE`, `SYNC`, `APPEND`, or `ASSIGN`. Default: `NONE`",
   withGroupsAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"groups_action" expected to be of type "string"';
+    assert std.isString(value) : '"groups_action" expected to be of type "string"';
+
     {
-      groups_action: converted,
+      groups_action: value,
     }
   ),
+
   "#withGroupsAssignment":: "List of Okta Group IDs to add an IdP user as a member with the `ASSIGN` `groups_action`.",
   withGroupsAssignment(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_assignment" expected to be of type "set"';
+
     {
       groups_assignment: converted,
     }
   ),
+
   "#withGroupsAssignmentMixin":: "List of Okta Group IDs to add an IdP user as a member with the `ASSIGN` `groups_action`.",
   withGroupsAssignmentMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_assignment" expected to be of type "set"';
+
     {
       groups_assignment+: converted,
     }
   ),
+
   "#withGroupsAttribute":: "IdP user profile attribute name (case-insensitive) for an array value that contains group memberships.",
   withGroupsAttribute(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"groups_attribute" expected to be of type "string"';
+    assert std.isString(value) : '"groups_attribute" expected to be of type "string"';
+
     {
-      groups_attribute: converted,
+      groups_attribute: value,
     }
   ),
+
   "#withGroupsFilter":: "Whitelist of Okta Group identifiers that are allowed for the `APPEND` or `SYNC` `groups_action`.",
   withGroupsFilter(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_filter" expected to be of type "set"';
+
     {
       groups_filter: converted,
     }
   ),
+
   "#withGroupsFilterMixin":: "Whitelist of Okta Group identifiers that are allowed for the `APPEND` or `SYNC` `groups_action`.",
   withGroupsFilterMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_filter" expected to be of type "set"';
+
     {
       groups_filter+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIssuerMode":: "Indicates whether Okta uses the original Okta org domain URL, or a custom domain URL. It can be `ORG_URL` or `CUSTOM_URL`. Default: `ORG_URL`",
   withIssuerMode(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"issuer_mode" expected to be of type "string"';
+    assert std.isString(value) : '"issuer_mode" expected to be of type "string"';
+
     {
-      issuer_mode: converted,
+      issuer_mode: value,
     }
   ),
+
   "#withMaxClockSkew":: "Maximum allowable clock-skew when processing messages from the IdP.",
   withMaxClockSkew(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"max_clock_skew" expected to be of type "number"';
+    assert std.isNumber(value) : '"max_clock_skew" expected to be of type "number"';
+
     {
-      max_clock_skew: converted,
+      max_clock_skew: value,
     }
   ),
+
   "#withName":: "Name of the IdP",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withProfileMaster":: "Determines if the IdP should act as a source of truth for user profile attributes.",
   withProfileMaster(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"profile_master" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"profile_master" expected to be of type "bool"';
+
     {
-      profile_master: converted,
+      profile_master: value,
     }
   ),
+
   "#withProtocolType":: "The type of protocol to use. It can be `OIDC` or `OAUTH2`. Default: `OAUTH2`",
   withProtocolType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"protocol_type" expected to be of type "string"';
+    assert std.isString(value) : '"protocol_type" expected to be of type "string"';
+
     {
-      protocol_type: converted,
+      protocol_type: value,
     }
   ),
+
   "#withProvisioningAction":: "Provisioning action for an IdP user during authentication. Default: `AUTO`",
   withProvisioningAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"provisioning_action" expected to be of type "string"';
+    assert std.isString(value) : '"provisioning_action" expected to be of type "string"';
+
     {
-      provisioning_action: converted,
+      provisioning_action: value,
     }
   ),
+
   "#withScopes":: "The scopes of the IdP.",
   withScopes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"scopes" expected to be of type "set"';
+
     {
       scopes: converted,
     }
   ),
+
   "#withScopesMixin":: "The scopes of the IdP.",
   withScopesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"scopes" expected to be of type "set"';
+
     {
       scopes+: converted,
     }
   ),
+
   "#withStatus":: "Default to `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withSubjectMatchAttribute":: "Okta user profile attribute for matching transformed IdP username. Only for matchType `CUSTOM_ATTRIBUTE`.",
   withSubjectMatchAttribute(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"subject_match_attribute" expected to be of type "string"';
+    assert std.isString(value) : '"subject_match_attribute" expected to be of type "string"';
+
     {
-      subject_match_attribute: converted,
+      subject_match_attribute: value,
     }
   ),
+
   "#withSubjectMatchType":: "Determines the Okta user profile attribute match conditions for account linking and authentication of the transformed IdP username. By default, it is set to `USERNAME`. It can be set to `USERNAME`, `EMAIL`, `USERNAME_OR_EMAIL` or `CUSTOM_ATTRIBUTE`.",
   withSubjectMatchType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"subject_match_type" expected to be of type "string"';
+    assert std.isString(value) : '"subject_match_type" expected to be of type "string"';
+
     {
-      subject_match_type: converted,
+      subject_match_type: value,
     }
   ),
+
   "#withSuspendedAction":: "Action for a previously suspended IdP user during authentication. Can be `NONE` or `REACTIVATE`. Default: `NONE`",
   withSuspendedAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"suspended_action" expected to be of type "string"';
+    assert std.isString(value) : '"suspended_action" expected to be of type "string"';
+
     {
-      suspended_action: converted,
+      suspended_action: value,
     }
   ),
+
   "#withType":: "Identity Provider Types: https://developer.okta.com/docs/reference/api/idps/#identity-provider-type",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
+
   "#withUsernameTemplate":: "Okta EL Expression to generate or transform a unique username for the IdP user. Default: `idpuser.email`",
   withUsernameTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"username_template" expected to be of type "string"';
+    assert std.isString(value) : '"username_template" expected to be of type "string"';
+
     {
-      username_template: converted,
+      username_template: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_inline_hook.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_inline_hook.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name, type, version):: (
     {
       jsonnetTfMetadata:: {
@@ -15,65 +16,73 @@
     + block.withType(type)
     + block.withVersion(version)
   ),
+
   withAuth(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"auth" expected to be of type "map"';
+    assert std.isObject(value) : '"auth" expected to be of type "map"';
+
     {
-      auth: converted,
+      auth: value,
     }
   ),
+
   withChannel(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"channel" expected to be of type "map"';
+    assert std.isObject(value) : '"channel" expected to be of type "map"';
+
     {
-      channel: converted,
+      channel: value,
     }
   ),
+
   "#withChannelJson":: "true channel object for the inline hook API contract",
   withChannelJson(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"channel_json" expected to be of type "string"';
+    assert std.isString(value) : '"channel_json" expected to be of type "string"';
+
     {
-      channel_json: converted,
+      channel_json: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "The inline hook display name.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withStatus":: "Default to `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withType":: "The type of hook to create. [See here for supported types](https://developer.okta.com/docs/reference/api/inline-hooks/#supported-inline-hook-types).",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
+
   "#withVersion":: "The version of the hook. The currently-supported version is `1.0.0`.",
   withVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"version" expected to be of type "string"';
+    assert std.isString(value) : '"version" expected to be of type "string"';
+
     {
-      version: converted,
+      version: value,
     }
   ),
   withTerraformName(value):: {
@@ -83,30 +92,34 @@
       },
     },
   },
+
   headers:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withKey(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"key" expected to be of type "string"';
+      assert std.isString(value) : '"key" expected to be of type "string"';
+
       {
-        key: converted,
+        key: value,
       }
     ),
+
     withValue(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"value" expected to be of type "string"';
+      assert std.isString(value) : '"value" expected to be of type "string"';
+
       {
-        value: converted,
+        value: value,
       }
     ),
   },
   withHeaders(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      headers: value,
+      headers: converted,
     }
   ),
   withHeadersMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_link_definition.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_link_definition.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, associatedDescription, associatedName, associatedTitle, primaryDescription, primaryName, primaryTitle):: (
     {
       jsonnetTfMetadata:: {
@@ -18,59 +19,66 @@
     + block.withPrimaryName(primaryName)
     + block.withPrimaryTitle(primaryTitle)
   ),
+
   "#withAssociatedDescription":: "Description of the associated relationship.",
   withAssociatedDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"associated_description" expected to be of type "string"';
+    assert std.isString(value) : '"associated_description" expected to be of type "string"';
+
     {
-      associated_description: converted,
+      associated_description: value,
     }
   ),
+
   "#withAssociatedName":: "API name of the associated link.",
   withAssociatedName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"associated_name" expected to be of type "string"';
+    assert std.isString(value) : '"associated_name" expected to be of type "string"';
+
     {
-      associated_name: converted,
+      associated_name: value,
     }
   ),
+
   "#withAssociatedTitle":: "Display name of the associated link.",
   withAssociatedTitle(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"associated_title" expected to be of type "string"';
+    assert std.isString(value) : '"associated_title" expected to be of type "string"';
+
     {
-      associated_title: converted,
+      associated_title: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withPrimaryDescription":: "Description of the primary relationship.",
   withPrimaryDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"primary_description" expected to be of type "string"';
+    assert std.isString(value) : '"primary_description" expected to be of type "string"';
+
     {
-      primary_description: converted,
+      primary_description: value,
     }
   ),
+
   "#withPrimaryName":: "API name of the primary link.",
   withPrimaryName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"primary_name" expected to be of type "string"';
+    assert std.isString(value) : '"primary_name" expected to be of type "string"';
+
     {
-      primary_name: converted,
+      primary_name: value,
     }
   ),
+
   "#withPrimaryTitle":: "Display name of the primary link.",
   withPrimaryTitle(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"primary_title" expected to be of type "string"';
+    assert std.isString(value) : '"primary_title" expected to be of type "string"';
+
     {
-      primary_title: converted,
+      primary_title: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_link_value.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_link_value.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, primaryName, primaryUserId):: (
     {
       jsonnetTfMetadata:: {
@@ -14,43 +15,50 @@
     + block.withPrimaryName(primaryName)
     + block.withPrimaryUserId(primaryUserId)
   ),
+
   "#withAssociatedUserIds":: "Set of User IDs or login values of the users to be assigned the `associated` relationship.",
   withAssociatedUserIds(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"associated_user_ids" expected to be of type "set"';
+
     {
       associated_user_ids: converted,
     }
   ),
+
   "#withAssociatedUserIdsMixin":: "Set of User IDs or login values of the users to be assigned the `associated` relationship.",
   withAssociatedUserIdsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"associated_user_ids" expected to be of type "set"';
+
     {
       associated_user_ids+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withPrimaryName":: "Name of the `primary` relationship being assigned.",
   withPrimaryName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"primary_name" expected to be of type "string"';
+    assert std.isString(value) : '"primary_name" expected to be of type "string"';
+
     {
-      primary_name: converted,
+      primary_name: value,
     }
   ),
+
   "#withPrimaryUserId":: "User ID to be assigned to `primary` for the 'associated' user in the specified relationship.",
   withPrimaryUserId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"primary_user_id" expected to be of type "string"';
+    assert std.isString(value) : '"primary_user_id" expected to be of type "string"';
+
     {
-      primary_user_id: converted,
+      primary_user_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_log_stream.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_log_stream.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name, type):: (
     {
       jsonnetTfMetadata:: {
@@ -14,28 +15,31 @@
     + block.withName(name)
     + block.withType(type)
   ),
+
   "#withName":: "Unique name for the Log Stream object",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withStatus":: "Stream status",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withType":: "Streaming provider used - 'aws_eventbridge' or 'splunk_cloud_logstreaming'",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
   withTerraformName(value):: {
@@ -45,62 +49,69 @@
       },
     },
   },
+
   settings:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     "#withAccountId":: "AWS account ID. Required only for 'aws_eventbridge' type",
     withAccountId(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"account_id" expected to be of type "string"';
+      assert std.isString(value) : '"account_id" expected to be of type "string"';
+
       {
-        account_id: converted,
+        account_id: value,
       }
     ),
+
     "#withEdition":: "Edition of the Splunk Cloud instance. Could be one of: 'aws', 'aws_govcloud', 'gcp'. Required only for 'splunk_cloud_logstreaming' type",
     withEdition(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"edition" expected to be of type "string"';
+      assert std.isString(value) : '"edition" expected to be of type "string"';
+
       {
-        edition: converted,
+        edition: value,
       }
     ),
+
     "#withEventSourceName":: "An alphanumeric name (no spaces) to identify this event source in AWS EventBridge. Required only for 'aws_eventbridge' type",
     withEventSourceName(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"event_source_name" expected to be of type "string"';
+      assert std.isString(value) : '"event_source_name" expected to be of type "string"';
+
       {
-        event_source_name: converted,
+        event_source_name: value,
       }
     ),
+
     "#withHost":: "The domain name for Splunk Cloud instance. Don't include http or https in the string. For example: 'acme.splunkcloud.com'. Required only for 'splunk_cloud_logstreaming' type",
     withHost(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"host" expected to be of type "string"';
+      assert std.isString(value) : '"host" expected to be of type "string"';
+
       {
-        host: converted,
+        host: value,
       }
     ),
+
     "#withRegion":: "The destination AWS region where event source is located. Required only for 'aws_eventbridge' type",
     withRegion(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"region" expected to be of type "string"';
+      assert std.isString(value) : '"region" expected to be of type "string"';
+
       {
-        region: converted,
+        region: value,
       }
     ),
+
     "#withToken":: "The HEC token for your Splunk Cloud HTTP Event Collector. Required only for 'splunk_cloud_logstreaming' type",
     withToken(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"token" expected to be of type "string"';
+      assert std.isString(value) : '"token" expected to be of type "string"';
+
       {
-        token: converted,
+        token: value,
       }
     ),
   },
   withSettings(value):: (
-    local converted = value;
     {
       settings: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_network_zone.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_network_zone.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name, type):: (
     {
       jsonnetTfMetadata:: {
@@ -14,163 +15,197 @@
     + block.withName(name)
     + block.withType(type)
   ),
+
   "#withAsns":: "List of asns included. Format of each array value: a string representation of an ASN numeric value. Use with type `DYNAMIC` or `DYNAMIC_V2`",
   withAsns(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"asns" expected to be of type "set"';
+
     {
       asns: converted,
     }
   ),
+
   "#withAsnsMixin":: "List of asns included. Format of each array value: a string representation of an ASN numeric value. Use with type `DYNAMIC` or `DYNAMIC_V2`",
   withAsnsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"asns" expected to be of type "set"';
+
     {
       asns+: converted,
     }
   ),
+
   "#withDynamicLocations":: "Array of locations ISO-3166-1(2) included. Format code: countryCode OR countryCode-regionCode. Use with type `DYNAMIC` or `DYNAMIC_V2`",
   withDynamicLocations(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"dynamic_locations" expected to be of type "set"';
+
     {
       dynamic_locations: converted,
     }
   ),
+
   "#withDynamicLocationsMixin":: "Array of locations ISO-3166-1(2) included. Format code: countryCode OR countryCode-regionCode. Use with type `DYNAMIC` or `DYNAMIC_V2`",
   withDynamicLocationsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"dynamic_locations" expected to be of type "set"';
+
     {
       dynamic_locations+: converted,
     }
   ),
+
   "#withDynamicLocationsExclude":: "Array of locations ISO-3166-1(2) excluded. Format code: countryCode OR countryCode-regionCode. Use with type `DYNAMIC_V2`",
   withDynamicLocationsExclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"dynamic_locations_exclude" expected to be of type "set"';
+
     {
       dynamic_locations_exclude: converted,
     }
   ),
+
   "#withDynamicLocationsExcludeMixin":: "Array of locations ISO-3166-1(2) excluded. Format code: countryCode OR countryCode-regionCode. Use with type `DYNAMIC_V2`",
   withDynamicLocationsExcludeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"dynamic_locations_exclude" expected to be of type "set"';
+
     {
       dynamic_locations_exclude+: converted,
     }
   ),
+
   "#withDynamicProxyType":: "Type of proxy being controlled by this dynamic network zone - can be one of `Any`, `TorAnonymizer` or `NotTorAnonymizer`. Use with type `DYNAMIC`",
   withDynamicProxyType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"dynamic_proxy_type" expected to be of type "string"';
+    assert std.isString(value) : '"dynamic_proxy_type" expected to be of type "string"';
+
     {
-      dynamic_proxy_type: converted,
+      dynamic_proxy_type: value,
     }
   ),
+
   "#withGateways":: "Array of values in CIDR/range form depending on the way it's been declared (i.e. CIDR will contain /suffix). Please check API docs for examples. Use with type `IP`",
   withGateways(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"gateways" expected to be of type "set"';
+
     {
       gateways: converted,
     }
   ),
+
   "#withGatewaysMixin":: "Array of values in CIDR/range form depending on the way it's been declared (i.e. CIDR will contain /suffix). Please check API docs for examples. Use with type `IP`",
   withGatewaysMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"gateways" expected to be of type "set"';
+
     {
       gateways+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIpServiceCategoriesExclude":: "List of ip service excluded. Use with type `DYNAMIC_V2`",
   withIpServiceCategoriesExclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"ip_service_categories_exclude" expected to be of type "set"';
+
     {
       ip_service_categories_exclude: converted,
     }
   ),
+
   "#withIpServiceCategoriesExcludeMixin":: "List of ip service excluded. Use with type `DYNAMIC_V2`",
   withIpServiceCategoriesExcludeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"ip_service_categories_exclude" expected to be of type "set"';
+
     {
       ip_service_categories_exclude+: converted,
     }
   ),
+
   "#withIpServiceCategoriesInclude":: "List of ip service included. Use with type `DYNAMIC_V2`",
   withIpServiceCategoriesInclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"ip_service_categories_include" expected to be of type "set"';
+
     {
       ip_service_categories_include: converted,
     }
   ),
+
   "#withIpServiceCategoriesIncludeMixin":: "List of ip service included. Use with type `DYNAMIC_V2`",
   withIpServiceCategoriesIncludeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"ip_service_categories_include" expected to be of type "set"';
+
     {
       ip_service_categories_include+: converted,
     }
   ),
+
   "#withName":: "Name of the Network Zone Resource",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withProxies":: "Array of values in CIDR/range form depending on the way it's been declared (i.e. CIDR will contain /suffix). Please check API docs for examples. Can not be set if `usage` is set to `BLOCKLIST`. Use with type `IP`",
   withProxies(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"proxies" expected to be of type "set"';
+
     {
       proxies: converted,
     }
   ),
+
   "#withProxiesMixin":: "Array of values in CIDR/range form depending on the way it's been declared (i.e. CIDR will contain /suffix). Please check API docs for examples. Can not be set if `usage` is set to `BLOCKLIST`. Use with type `IP`",
   withProxiesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"proxies" expected to be of type "set"';
+
     {
       proxies+: converted,
     }
   ),
+
   "#withStatus":: "Network Status - can either be `ACTIVE` or `INACTIVE` only",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withType":: "Type of the Network Zone - can be `IP`, `DYNAMIC` or `DYNAMIC_V2` only",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
+
   "#withUsage":: "Usage of the Network Zone - can be either `POLICY` or `BLOCKLIST`. By default, it is `POLICY`",
   withUsage(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"usage" expected to be of type "string"';
+    assert std.isString(value) : '"usage" expected to be of type "string"';
+
     {
-      usage: converted,
+      usage: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_org_configuration.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_org_configuration.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, companyName):: (
     {
       jsonnetTfMetadata:: {
@@ -13,131 +14,147 @@
     }
     + block.withCompanyName(companyName)
   ),
+
   "#withAddress_1":: "Primary address of org",
   withAddress_1(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"address_1" expected to be of type "string"';
+    assert std.isString(value) : '"address_1" expected to be of type "string"';
+
     {
-      address_1: converted,
+      address_1: value,
     }
   ),
+
   "#withAddress_2":: "Secondary address of org",
   withAddress_2(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"address_2" expected to be of type "string"';
+    assert std.isString(value) : '"address_2" expected to be of type "string"';
+
     {
-      address_2: converted,
+      address_2: value,
     }
   ),
+
   "#withBillingContactUser":: "User ID representing the billing contact",
   withBillingContactUser(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"billing_contact_user" expected to be of type "string"';
+    assert std.isString(value) : '"billing_contact_user" expected to be of type "string"';
+
     {
-      billing_contact_user: converted,
+      billing_contact_user: value,
     }
   ),
+
   "#withCity":: "City of org",
   withCity(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"city" expected to be of type "string"';
+    assert std.isString(value) : '"city" expected to be of type "string"';
+
     {
-      city: converted,
+      city: value,
     }
   ),
+
   "#withCompanyName":: "Name of org",
   withCompanyName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"company_name" expected to be of type "string"';
+    assert std.isString(value) : '"company_name" expected to be of type "string"';
+
     {
-      company_name: converted,
+      company_name: value,
     }
   ),
+
   "#withCountry":: "Country of org",
   withCountry(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"country" expected to be of type "string"';
+    assert std.isString(value) : '"country" expected to be of type "string"';
+
     {
-      country: converted,
+      country: value,
     }
   ),
+
   "#withEndUserSupportHelpUrl":: "Support link of org",
   withEndUserSupportHelpUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"end_user_support_help_url" expected to be of type "string"';
+    assert std.isString(value) : '"end_user_support_help_url" expected to be of type "string"';
+
     {
-      end_user_support_help_url: converted,
+      end_user_support_help_url: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLogo":: "Logo of org. The file must be in PNG, JPG, or GIF format and less than 1 MB in size. For best results use landscape orientation, a transparent background, and a minimum size of 420px by 120px to prevent upscaling.",
   withLogo(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"logo" expected to be of type "string"';
+    assert std.isString(value) : '"logo" expected to be of type "string"';
+
     {
-      logo: converted,
+      logo: value,
     }
   ),
+
   "#withOptOutCommunicationEmails":: "Indicates whether the org's users receive Okta Communication emails",
   withOptOutCommunicationEmails(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"opt_out_communication_emails" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"opt_out_communication_emails" expected to be of type "bool"';
+
     {
-      opt_out_communication_emails: converted,
+      opt_out_communication_emails: value,
     }
   ),
+
   "#withPhoneNumber":: "Support help phone of org",
   withPhoneNumber(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"phone_number" expected to be of type "string"';
+    assert std.isString(value) : '"phone_number" expected to be of type "string"';
+
     {
-      phone_number: converted,
+      phone_number: value,
     }
   ),
+
   "#withPostalCode":: "Postal code of org",
   withPostalCode(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"postal_code" expected to be of type "string"';
+    assert std.isString(value) : '"postal_code" expected to be of type "string"';
+
     {
-      postal_code: converted,
+      postal_code: value,
     }
   ),
+
   "#withState":: "State of org",
   withState(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"state" expected to be of type "string"';
+    assert std.isString(value) : '"state" expected to be of type "string"';
+
     {
-      state: converted,
+      state: value,
     }
   ),
+
   "#withSupportPhoneNumber":: "Support help phone of org",
   withSupportPhoneNumber(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"support_phone_number" expected to be of type "string"';
+    assert std.isString(value) : '"support_phone_number" expected to be of type "string"';
+
     {
-      support_phone_number: converted,
+      support_phone_number: value,
     }
   ),
+
   "#withTechnicalContactUser":: "User ID representing the technical contact",
   withTechnicalContactUser(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"technical_contact_user" expected to be of type "string"';
+    assert std.isString(value) : '"technical_contact_user" expected to be of type "string"';
+
     {
-      technical_contact_user: converted,
+      technical_contact_user: value,
     }
   ),
+
   "#withWebsite":: "The org's website",
   withWebsite(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"website" expected to be of type "string"';
+    assert std.isString(value) : '"website" expected to be of type "string"';
+
     {
-      website: converted,
+      website: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_org_support.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_org_support.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,19 +13,21 @@
       },
     }
   ),
+
   "#withExtendBy":: "Number of days the support should be extended by",
   withExtendBy(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"extend_by" expected to be of type "number"';
+    assert std.isNumber(value) : '"extend_by" expected to be of type "number"';
+
     {
-      extend_by: converted,
+      extend_by: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_device_assurance_android.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_device_assurance_android.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,68 +14,80 @@
     }
     + block.withName(name)
   ),
+
   "#withDiskEncryptionType":: "List of disk encryption type, can be `FULL`, `USER`",
   withDiskEncryptionType(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"disk_encryption_type" expected to be of type "set"';
+
     {
       disk_encryption_type: converted,
     }
   ),
+
   "#withDiskEncryptionTypeMixin":: "List of disk encryption type, can be `FULL`, `USER`",
   withDiskEncryptionTypeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"disk_encryption_type" expected to be of type "set"';
+
     {
       disk_encryption_type+: converted,
     }
   ),
+
   "#withJailbreak":: "Is the device jailbroken in the device assurance policy.",
   withJailbreak(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"jailbreak" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"jailbreak" expected to be of type "bool"';
+
     {
-      jailbreak: converted,
+      jailbreak: value,
     }
   ),
+
   "#withName":: "Policy device assurance name",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withOsVersion":: "Minimum os version of the device in the device assurance policy.",
   withOsVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"os_version" expected to be of type "string"';
+    assert std.isString(value) : '"os_version" expected to be of type "string"';
+
     {
-      os_version: converted,
+      os_version: value,
     }
   ),
+
   "#withScreenlockType":: "List of screenlock type, can be `BIOMETRIC` or `BIOMETRIC, PASSCODE`",
   withScreenlockType(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"screenlock_type" expected to be of type "set"';
+
     {
       screenlock_type: converted,
     }
   ),
+
   "#withScreenlockTypeMixin":: "List of screenlock type, can be `BIOMETRIC` or `BIOMETRIC, PASSCODE`",
   withScreenlockTypeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"screenlock_type" expected to be of type "set"';
+
     {
       screenlock_type+: converted,
     }
   ),
+
   "#withSecureHardwarePresent":: "Indicates if the device contains a secure hardware functionality",
   withSecureHardwarePresent(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"secure_hardware_present" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"secure_hardware_present" expected to be of type "bool"';
+
     {
-      secure_hardware_present: converted,
+      secure_hardware_present: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_device_assurance_chromeos.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_device_assurance_chromeos.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,124 +14,139 @@
     }
     + block.withName(name)
   ),
+
   "#withName":: "Name of the device assurance policy.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withTpspAllowScreenLock":: "Third party signal provider allow screen lock",
   withTpspAllowScreenLock(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_allow_screen_lock" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_allow_screen_lock" expected to be of type "bool"';
+
     {
-      tpsp_allow_screen_lock: converted,
+      tpsp_allow_screen_lock: value,
     }
   ),
+
   "#withTpspBrowserVersion":: "Third party signal provider minimum browser version",
   withTpspBrowserVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_browser_version" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_browser_version" expected to be of type "string"';
+
     {
-      tpsp_browser_version: converted,
+      tpsp_browser_version: value,
     }
   ),
+
   "#withTpspBuiltinDnsClientEnabled":: "Third party signal provider builtin dns client enabled",
   withTpspBuiltinDnsClientEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_builtin_dns_client_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_builtin_dns_client_enabled" expected to be of type "bool"';
+
     {
-      tpsp_builtin_dns_client_enabled: converted,
+      tpsp_builtin_dns_client_enabled: value,
     }
   ),
+
   "#withTpspChromeRemoteDesktopAppBlocked":: "Third party signal provider chrome remote desktop app blocked",
   withTpspChromeRemoteDesktopAppBlocked(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_chrome_remote_desktop_app_blocked" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_chrome_remote_desktop_app_blocked" expected to be of type "bool"';
+
     {
-      tpsp_chrome_remote_desktop_app_blocked: converted,
+      tpsp_chrome_remote_desktop_app_blocked: value,
     }
   ),
+
   "#withTpspDeviceEnrollmentDomain":: "Third party signal provider device enrollment domain",
   withTpspDeviceEnrollmentDomain(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_device_enrollment_domain" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_device_enrollment_domain" expected to be of type "string"';
+
     {
-      tpsp_device_enrollment_domain: converted,
+      tpsp_device_enrollment_domain: value,
     }
   ),
+
   "#withTpspDiskEncrypted":: "Third party signal provider disk encrypted",
   withTpspDiskEncrypted(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_disk_encrypted" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_disk_encrypted" expected to be of type "bool"';
+
     {
-      tpsp_disk_encrypted: converted,
+      tpsp_disk_encrypted: value,
     }
   ),
+
   "#withTpspKeyTrustLevel":: "Third party signal provider key trust level",
   withTpspKeyTrustLevel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_key_trust_level" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_key_trust_level" expected to be of type "string"';
+
     {
-      tpsp_key_trust_level: converted,
+      tpsp_key_trust_level: value,
     }
   ),
+
   "#withTpspOsFirewall":: "Third party signal provider os firewall",
   withTpspOsFirewall(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_os_firewall" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_os_firewall" expected to be of type "bool"';
+
     {
-      tpsp_os_firewall: converted,
+      tpsp_os_firewall: value,
     }
   ),
+
   "#withTpspOsVersion":: "Third party signal provider minimum os version",
   withTpspOsVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_os_version" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_os_version" expected to be of type "string"';
+
     {
-      tpsp_os_version: converted,
+      tpsp_os_version: value,
     }
   ),
+
   "#withTpspPasswordProctectionWarningTrigger":: "Third party signal provider password protection warning trigger",
   withTpspPasswordProctectionWarningTrigger(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_password_proctection_warning_trigger" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_password_proctection_warning_trigger" expected to be of type "string"';
+
     {
-      tpsp_password_proctection_warning_trigger: converted,
+      tpsp_password_proctection_warning_trigger: value,
     }
   ),
+
   "#withTpspRealtimeUrlCheckMode":: "Third party signal provider realtime url check mode",
   withTpspRealtimeUrlCheckMode(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_realtime_url_check_mode" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_realtime_url_check_mode" expected to be of type "bool"';
+
     {
-      tpsp_realtime_url_check_mode: converted,
+      tpsp_realtime_url_check_mode: value,
     }
   ),
+
   "#withTpspSafeBrowsingProtectionLevel":: "Third party signal provider safe browsing protection level",
   withTpspSafeBrowsingProtectionLevel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_safe_browsing_protection_level" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_safe_browsing_protection_level" expected to be of type "string"';
+
     {
-      tpsp_safe_browsing_protection_level: converted,
+      tpsp_safe_browsing_protection_level: value,
     }
   ),
+
   "#withTpspScreenLockSecured":: "Third party signal provider screen lock secure",
   withTpspScreenLockSecured(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_screen_lock_secured" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_screen_lock_secured" expected to be of type "bool"';
+
     {
-      tpsp_screen_lock_secured: converted,
+      tpsp_screen_lock_secured: value,
     }
   ),
+
   "#withTpspSiteIsolationEnabled":: "Third party signal provider site isolation enabled",
   withTpspSiteIsolationEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_site_isolation_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_site_isolation_enabled" expected to be of type "bool"';
+
     {
-      tpsp_site_isolation_enabled: converted,
+      tpsp_site_isolation_enabled: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_device_assurance_ios.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_device_assurance_ios.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,42 +14,49 @@
     }
     + block.withName(name)
   ),
+
   "#withJailbreak":: "Is the device jailbroken in the device assurance policy.",
   withJailbreak(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"jailbreak" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"jailbreak" expected to be of type "bool"';
+
     {
-      jailbreak: converted,
+      jailbreak: value,
     }
   ),
+
   "#withName":: "Name of the device assurance policy.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withOsVersion":: "Minimum os version of the device in the device assurance policy.",
   withOsVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"os_version" expected to be of type "string"';
+    assert std.isString(value) : '"os_version" expected to be of type "string"';
+
     {
-      os_version: converted,
+      os_version: value,
     }
   ),
+
   "#withScreenlockType":: "List of screenlock type, can be `BIOMETRIC` or `BIOMETRIC, PASSCODE`",
   withScreenlockType(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"screenlock_type" expected to be of type "set"';
+
     {
       screenlock_type: converted,
     }
   ),
+
   "#withScreenlockTypeMixin":: "List of screenlock type, can be `BIOMETRIC` or `BIOMETRIC, PASSCODE`",
   withScreenlockTypeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"screenlock_type" expected to be of type "set"';
+
     {
       screenlock_type+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_device_assurance_macos.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_device_assurance_macos.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,172 +14,197 @@
     }
     + block.withName(name)
   ),
+
   "#withDiskEncryptionType":: "List of disk encryption type, can be `ALL_INTERNAL_VOLUMES`",
   withDiskEncryptionType(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"disk_encryption_type" expected to be of type "set"';
+
     {
       disk_encryption_type: converted,
     }
   ),
+
   "#withDiskEncryptionTypeMixin":: "List of disk encryption type, can be `ALL_INTERNAL_VOLUMES`",
   withDiskEncryptionTypeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"disk_encryption_type" expected to be of type "set"';
+
     {
       disk_encryption_type+: converted,
     }
   ),
+
   "#withName":: "Name of the device assurance policy.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withOsVersion":: "Minimum os version of the device in the device assurance policy.",
   withOsVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"os_version" expected to be of type "string"';
+    assert std.isString(value) : '"os_version" expected to be of type "string"';
+
     {
-      os_version: converted,
+      os_version: value,
     }
   ),
+
   "#withScreenlockType":: "List of screenlock type, can be `BIOMETRIC` or `BIOMETRIC, PASSCODE`",
   withScreenlockType(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"screenlock_type" expected to be of type "set"';
+
     {
       screenlock_type: converted,
     }
   ),
+
   "#withScreenlockTypeMixin":: "List of screenlock type, can be `BIOMETRIC` or `BIOMETRIC, PASSCODE`",
   withScreenlockTypeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"screenlock_type" expected to be of type "set"';
+
     {
       screenlock_type+: converted,
     }
   ),
+
   "#withSecureHardwarePresent":: "Is the device secure with hardware in the device assurance policy.",
   withSecureHardwarePresent(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"secure_hardware_present" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"secure_hardware_present" expected to be of type "bool"';
+
     {
-      secure_hardware_present: converted,
+      secure_hardware_present: value,
     }
   ),
+
   "#withThirdPartySignalProviders":: "Check to include third party signal provider",
   withThirdPartySignalProviders(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"third_party_signal_providers" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"third_party_signal_providers" expected to be of type "bool"';
+
     {
-      third_party_signal_providers: converted,
+      third_party_signal_providers: value,
     }
   ),
+
   "#withTpspBrowserVersion":: "Third party signal provider minimum browser version",
   withTpspBrowserVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_browser_version" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_browser_version" expected to be of type "string"';
+
     {
-      tpsp_browser_version: converted,
+      tpsp_browser_version: value,
     }
   ),
+
   "#withTpspBuiltinDnsClientEnabled":: "Third party signal provider builtin dns client enable",
   withTpspBuiltinDnsClientEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_builtin_dns_client_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_builtin_dns_client_enabled" expected to be of type "bool"';
+
     {
-      tpsp_builtin_dns_client_enabled: converted,
+      tpsp_builtin_dns_client_enabled: value,
     }
   ),
+
   "#withTpspChromeRemoteDesktopAppBlocked":: "Third party signal provider chrome remote desktop app blocked",
   withTpspChromeRemoteDesktopAppBlocked(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_chrome_remote_desktop_app_blocked" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_chrome_remote_desktop_app_blocked" expected to be of type "bool"';
+
     {
-      tpsp_chrome_remote_desktop_app_blocked: converted,
+      tpsp_chrome_remote_desktop_app_blocked: value,
     }
   ),
+
   "#withTpspDeviceEnrollmentDomain":: "Third party signal provider device enrollment domain",
   withTpspDeviceEnrollmentDomain(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_device_enrollment_domain" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_device_enrollment_domain" expected to be of type "string"';
+
     {
-      tpsp_device_enrollment_domain: converted,
+      tpsp_device_enrollment_domain: value,
     }
   ),
+
   "#withTpspDiskEncrypted":: "Third party signal provider disk encrypted",
   withTpspDiskEncrypted(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_disk_encrypted" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_disk_encrypted" expected to be of type "bool"';
+
     {
-      tpsp_disk_encrypted: converted,
+      tpsp_disk_encrypted: value,
     }
   ),
+
   "#withTpspKeyTrustLevel":: "Third party signal provider key trust level",
   withTpspKeyTrustLevel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_key_trust_level" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_key_trust_level" expected to be of type "string"';
+
     {
-      tpsp_key_trust_level: converted,
+      tpsp_key_trust_level: value,
     }
   ),
+
   "#withTpspOsFirewall":: "Third party signal provider os firewall",
   withTpspOsFirewall(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_os_firewall" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_os_firewall" expected to be of type "bool"';
+
     {
-      tpsp_os_firewall: converted,
+      tpsp_os_firewall: value,
     }
   ),
+
   "#withTpspOsVersion":: "Third party signal provider minimum os version",
   withTpspOsVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_os_version" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_os_version" expected to be of type "string"';
+
     {
-      tpsp_os_version: converted,
+      tpsp_os_version: value,
     }
   ),
+
   "#withTpspPasswordProctectionWarningTrigger":: "Third party signal provider password protection warning trigger",
   withTpspPasswordProctectionWarningTrigger(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_password_proctection_warning_trigger" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_password_proctection_warning_trigger" expected to be of type "string"';
+
     {
-      tpsp_password_proctection_warning_trigger: converted,
+      tpsp_password_proctection_warning_trigger: value,
     }
   ),
+
   "#withTpspRealtimeUrlCheckMode":: "Third party signal provider realtime url check mode",
   withTpspRealtimeUrlCheckMode(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_realtime_url_check_mode" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_realtime_url_check_mode" expected to be of type "bool"';
+
     {
-      tpsp_realtime_url_check_mode: converted,
+      tpsp_realtime_url_check_mode: value,
     }
   ),
+
   "#withTpspSafeBrowsingProtectionLevel":: "Third party signal provider safe browsing protection level",
   withTpspSafeBrowsingProtectionLevel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_safe_browsing_protection_level" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_safe_browsing_protection_level" expected to be of type "string"';
+
     {
-      tpsp_safe_browsing_protection_level: converted,
+      tpsp_safe_browsing_protection_level: value,
     }
   ),
+
   "#withTpspScreenLockSecured":: "Third party signal provider screen lock secure",
   withTpspScreenLockSecured(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_screen_lock_secured" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_screen_lock_secured" expected to be of type "bool"';
+
     {
-      tpsp_screen_lock_secured: converted,
+      tpsp_screen_lock_secured: value,
     }
   ),
+
   "#withTpspSiteIsolationEnabled":: "Third party signal provider site isolation enabled",
   withTpspSiteIsolationEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_site_isolation_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_site_isolation_enabled" expected to be of type "bool"';
+
     {
-      tpsp_site_isolation_enabled: converted,
+      tpsp_site_isolation_enabled: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_device_assurance_windows.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_device_assurance_windows.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,220 +14,251 @@
     }
     + block.withName(name)
   ),
+
   "#withDiskEncryptionType":: "List of disk encryption type, can be `ALL_INTERNAL_VOLUMES`",
   withDiskEncryptionType(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"disk_encryption_type" expected to be of type "set"';
+
     {
       disk_encryption_type: converted,
     }
   ),
+
   "#withDiskEncryptionTypeMixin":: "List of disk encryption type, can be `ALL_INTERNAL_VOLUMES`",
   withDiskEncryptionTypeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"disk_encryption_type" expected to be of type "set"';
+
     {
       disk_encryption_type+: converted,
     }
   ),
+
   "#withName":: "Name of the device assurance policy.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withOsVersion":: "Minimum os version of the device in the device assurance policy.",
   withOsVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"os_version" expected to be of type "string"';
+    assert std.isString(value) : '"os_version" expected to be of type "string"';
+
     {
-      os_version: converted,
+      os_version: value,
     }
   ),
+
   "#withScreenlockType":: "List of screenlock type, can be `BIOMETRIC` or `BIOMETRIC, PASSCODE`",
   withScreenlockType(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"screenlock_type" expected to be of type "set"';
+
     {
       screenlock_type: converted,
     }
   ),
+
   "#withScreenlockTypeMixin":: "List of screenlock type, can be `BIOMETRIC` or `BIOMETRIC, PASSCODE`",
   withScreenlockTypeMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"screenlock_type" expected to be of type "set"';
+
     {
       screenlock_type+: converted,
     }
   ),
+
   "#withSecureHardwarePresent":: "Is the device secure with hardware in the device assurance policy.",
   withSecureHardwarePresent(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"secure_hardware_present" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"secure_hardware_present" expected to be of type "bool"';
+
     {
-      secure_hardware_present: converted,
+      secure_hardware_present: value,
     }
   ),
+
   "#withThirdPartySignalProviders":: "Check to include third party signal provider",
   withThirdPartySignalProviders(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"third_party_signal_providers" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"third_party_signal_providers" expected to be of type "bool"';
+
     {
-      third_party_signal_providers: converted,
+      third_party_signal_providers: value,
     }
   ),
+
   "#withTpspBrowserVersion":: "Third party signal provider minimum browser version",
   withTpspBrowserVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_browser_version" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_browser_version" expected to be of type "string"';
+
     {
-      tpsp_browser_version: converted,
+      tpsp_browser_version: value,
     }
   ),
+
   "#withTpspBuiltinDnsClientEnabled":: "Third party signal provider builtin dns client enable",
   withTpspBuiltinDnsClientEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_builtin_dns_client_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_builtin_dns_client_enabled" expected to be of type "bool"';
+
     {
-      tpsp_builtin_dns_client_enabled: converted,
+      tpsp_builtin_dns_client_enabled: value,
     }
   ),
+
   "#withTpspChromeRemoteDesktopAppBlocked":: "Third party signal provider chrome remote desktop app blocked",
   withTpspChromeRemoteDesktopAppBlocked(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_chrome_remote_desktop_app_blocked" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_chrome_remote_desktop_app_blocked" expected to be of type "bool"';
+
     {
-      tpsp_chrome_remote_desktop_app_blocked: converted,
+      tpsp_chrome_remote_desktop_app_blocked: value,
     }
   ),
+
   "#withTpspCrowdStrikeAgentId":: "Third party signal provider crowdstrike agent id",
   withTpspCrowdStrikeAgentId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_crowd_strike_agent_id" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_crowd_strike_agent_id" expected to be of type "string"';
+
     {
-      tpsp_crowd_strike_agent_id: converted,
+      tpsp_crowd_strike_agent_id: value,
     }
   ),
+
   "#withTpspCrowdStrikeCustomerId":: "Third party signal provider crowdstrike user id",
   withTpspCrowdStrikeCustomerId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_crowd_strike_customer_id" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_crowd_strike_customer_id" expected to be of type "string"';
+
     {
-      tpsp_crowd_strike_customer_id: converted,
+      tpsp_crowd_strike_customer_id: value,
     }
   ),
+
   "#withTpspDeviceEnrollmentDomain":: "Third party signal provider device enrollment domain",
   withTpspDeviceEnrollmentDomain(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_device_enrollment_domain" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_device_enrollment_domain" expected to be of type "string"';
+
     {
-      tpsp_device_enrollment_domain: converted,
+      tpsp_device_enrollment_domain: value,
     }
   ),
+
   "#withTpspDiskEncrypted":: "Third party signal provider disk encrypted",
   withTpspDiskEncrypted(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_disk_encrypted" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_disk_encrypted" expected to be of type "bool"';
+
     {
-      tpsp_disk_encrypted: converted,
+      tpsp_disk_encrypted: value,
     }
   ),
+
   "#withTpspKeyTrustLevel":: "Third party signal provider key trust level",
   withTpspKeyTrustLevel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_key_trust_level" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_key_trust_level" expected to be of type "string"';
+
     {
-      tpsp_key_trust_level: converted,
+      tpsp_key_trust_level: value,
     }
   ),
+
   "#withTpspOsFirewall":: "Third party signal provider os firewall",
   withTpspOsFirewall(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_os_firewall" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_os_firewall" expected to be of type "bool"';
+
     {
-      tpsp_os_firewall: converted,
+      tpsp_os_firewall: value,
     }
   ),
+
   "#withTpspOsVersion":: "Third party signal provider minimum os version",
   withTpspOsVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_os_version" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_os_version" expected to be of type "string"';
+
     {
-      tpsp_os_version: converted,
+      tpsp_os_version: value,
     }
   ),
+
   "#withTpspPasswordProctectionWarningTrigger":: "Third party signal provider password protection warning trigger",
   withTpspPasswordProctectionWarningTrigger(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_password_proctection_warning_trigger" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_password_proctection_warning_trigger" expected to be of type "string"';
+
     {
-      tpsp_password_proctection_warning_trigger: converted,
+      tpsp_password_proctection_warning_trigger: value,
     }
   ),
+
   "#withTpspRealtimeUrlCheckMode":: "Third party signal provider realtime url check mode",
   withTpspRealtimeUrlCheckMode(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_realtime_url_check_mode" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_realtime_url_check_mode" expected to be of type "bool"';
+
     {
-      tpsp_realtime_url_check_mode: converted,
+      tpsp_realtime_url_check_mode: value,
     }
   ),
+
   "#withTpspSafeBrowsingProtectionLevel":: "Third party signal provider safe browsing protection level",
   withTpspSafeBrowsingProtectionLevel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_safe_browsing_protection_level" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_safe_browsing_protection_level" expected to be of type "string"';
+
     {
-      tpsp_safe_browsing_protection_level: converted,
+      tpsp_safe_browsing_protection_level: value,
     }
   ),
+
   "#withTpspScreenLockSecured":: "Third party signal provider screen lock secure",
   withTpspScreenLockSecured(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_screen_lock_secured" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_screen_lock_secured" expected to be of type "bool"';
+
     {
-      tpsp_screen_lock_secured: converted,
+      tpsp_screen_lock_secured: value,
     }
   ),
+
   "#withTpspSecureBootEnabled":: "Third party signal provider secure boot enabled",
   withTpspSecureBootEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_secure_boot_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_secure_boot_enabled" expected to be of type "bool"';
+
     {
-      tpsp_secure_boot_enabled: converted,
+      tpsp_secure_boot_enabled: value,
     }
   ),
+
   "#withTpspSiteIsolationEnabled":: "Third party signal provider site isolation enabled",
   withTpspSiteIsolationEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_site_isolation_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_site_isolation_enabled" expected to be of type "bool"';
+
     {
-      tpsp_site_isolation_enabled: converted,
+      tpsp_site_isolation_enabled: value,
     }
   ),
+
   "#withTpspThirdPartyBlockingEnabled":: "Third party signal provider third party blocking enabled",
   withTpspThirdPartyBlockingEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"tpsp_third_party_blocking_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"tpsp_third_party_blocking_enabled" expected to be of type "bool"';
+
     {
-      tpsp_third_party_blocking_enabled: converted,
+      tpsp_third_party_blocking_enabled: value,
     }
   ),
+
   "#withTpspWindowsMachineDomain":: "Third party signal provider windows machine domain",
   withTpspWindowsMachineDomain(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_windows_machine_domain" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_windows_machine_domain" expected to be of type "string"';
+
     {
-      tpsp_windows_machine_domain: converted,
+      tpsp_windows_machine_domain: value,
     }
   ),
+
   "#withTpspWindowsUserDomain":: "Third party signal provider windows user domain",
   withTpspWindowsUserDomain(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"tpsp_windows_user_domain" expected to be of type "string"';
+    assert std.isString(value) : '"tpsp_windows_user_domain" expected to be of type "string"';
+
     {
-      tpsp_windows_user_domain: converted,
+      tpsp_windows_user_domain: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_mfa.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_mfa.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,235 +14,271 @@
     }
     + block.withName(name)
   ),
+
   "#withDescription":: "Policy Description",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   withDuo(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"duo" expected to be of type "map"';
+    assert std.isObject(value) : '"duo" expected to be of type "map"';
+
     {
-      duo: converted,
+      duo: value,
     }
   ),
+
   withExternalIdp(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"external_idp" expected to be of type "map"';
+    assert std.isObject(value) : '"external_idp" expected to be of type "map"';
+
     {
-      external_idp: converted,
+      external_idp: value,
     }
   ),
+
   withExternalIdps(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"external_idps" expected to be of type "set"';
+
     {
       external_idps: converted,
     }
   ),
+
   withExternalIdpsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"external_idps" expected to be of type "set"';
+
     {
       external_idps+: converted,
     }
   ),
+
   withFidoU2f(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"fido_u2f" expected to be of type "map"';
+    assert std.isObject(value) : '"fido_u2f" expected to be of type "map"';
+
     {
-      fido_u2f: converted,
+      fido_u2f: value,
     }
   ),
+
   withFidoWebauthn(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"fido_webauthn" expected to be of type "map"';
+    assert std.isObject(value) : '"fido_webauthn" expected to be of type "map"';
+
     {
-      fido_webauthn: converted,
+      fido_webauthn: value,
     }
   ),
+
   withGoogleOtp(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"google_otp" expected to be of type "map"';
+    assert std.isObject(value) : '"google_otp" expected to be of type "map"';
+
     {
-      google_otp: converted,
+      google_otp: value,
     }
   ),
+
   "#withGroupsIncluded":: "List of Group IDs to Include",
   withGroupsIncluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_included" expected to be of type "set"';
+
     {
       groups_included: converted,
     }
   ),
+
   "#withGroupsIncludedMixin":: "List of Group IDs to Include",
   withGroupsIncludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_included" expected to be of type "set"';
+
     {
       groups_included+: converted,
     }
   ),
+
   withHotp(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"hotp" expected to be of type "map"';
+    assert std.isObject(value) : '"hotp" expected to be of type "map"';
+
     {
-      hotp: converted,
+      hotp: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIsOie":: "Is the policy using Okta Identity Engine (OIE) with authenticators instead of factors?",
   withIsOie(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"is_oie" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"is_oie" expected to be of type "bool"';
+
     {
-      is_oie: converted,
+      is_oie: value,
     }
   ),
+
   "#withName":: "Policy Name",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   withOktaCall(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_call" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_call" expected to be of type "map"';
+
     {
-      okta_call: converted,
+      okta_call: value,
     }
   ),
+
   withOktaEmail(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_email" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_email" expected to be of type "map"';
+
     {
-      okta_email: converted,
+      okta_email: value,
     }
   ),
+
   withOktaOtp(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_otp" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_otp" expected to be of type "map"';
+
     {
-      okta_otp: converted,
+      okta_otp: value,
     }
   ),
+
   withOktaPassword(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_password" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_password" expected to be of type "map"';
+
     {
-      okta_password: converted,
+      okta_password: value,
     }
   ),
+
   withOktaPush(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_push" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_push" expected to be of type "map"';
+
     {
-      okta_push: converted,
+      okta_push: value,
     }
   ),
+
   withOktaQuestion(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_question" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_question" expected to be of type "map"';
+
     {
-      okta_question: converted,
+      okta_question: value,
     }
   ),
+
   withOktaSms(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_sms" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_sms" expected to be of type "map"';
+
     {
-      okta_sms: converted,
+      okta_sms: value,
     }
   ),
+
   withOktaVerify(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_verify" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_verify" expected to be of type "map"';
+
     {
-      okta_verify: converted,
+      okta_verify: value,
     }
   ),
+
   withOnpremMfa(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"onprem_mfa" expected to be of type "map"';
+    assert std.isObject(value) : '"onprem_mfa" expected to be of type "map"';
+
     {
-      onprem_mfa: converted,
+      onprem_mfa: value,
     }
   ),
+
   withPhoneNumber(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"phone_number" expected to be of type "map"';
+    assert std.isObject(value) : '"phone_number" expected to be of type "map"';
+
     {
-      phone_number: converted,
+      phone_number: value,
     }
   ),
+
   "#withPriority":: "Policy Priority, this attribute can be set to a valid priority. To avoid endless diff situation we error if an invalid priority is provided. API defaults it to the last (lowest) if not there.",
   withPriority(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+    assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
     {
-      priority: converted,
+      priority: value,
     }
   ),
+
   withRsaToken(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"rsa_token" expected to be of type "map"';
+    assert std.isObject(value) : '"rsa_token" expected to be of type "map"';
+
     {
-      rsa_token: converted,
+      rsa_token: value,
     }
   ),
+
   withSecurityQuestion(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"security_question" expected to be of type "map"';
+    assert std.isObject(value) : '"security_question" expected to be of type "map"';
+
     {
-      security_question: converted,
+      security_question: value,
     }
   ),
+
   withSmartCardIdp(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"smart_card_idp" expected to be of type "map"';
+    assert std.isObject(value) : '"smart_card_idp" expected to be of type "map"';
+
     {
-      smart_card_idp: converted,
+      smart_card_idp: value,
     }
   ),
+
   "#withStatus":: "Policy Status: `ACTIVE` or `INACTIVE`. Default: `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   withSymantecVip(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"symantec_vip" expected to be of type "map"';
+    assert std.isObject(value) : '"symantec_vip" expected to be of type "map"';
+
     {
-      symantec_vip: converted,
+      symantec_vip: value,
     }
   ),
+
   withWebauthn(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"webauthn" expected to be of type "map"';
+    assert std.isObject(value) : '"webauthn" expected to be of type "map"';
+
     {
-      webauthn: converted,
+      webauthn: value,
     }
   ),
+
   withYubikeyToken(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"yubikey_token" expected to be of type "map"';
+    assert std.isObject(value) : '"yubikey_token" expected to be of type "map"';
+
     {
-      yubikey_token: converted,
+      yubikey_token: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_mfa_default.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_mfa_default.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,187 +13,215 @@
       },
     }
   ),
+
   withDuo(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"duo" expected to be of type "map"';
+    assert std.isObject(value) : '"duo" expected to be of type "map"';
+
     {
-      duo: converted,
+      duo: value,
     }
   ),
+
   withExternalIdp(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"external_idp" expected to be of type "map"';
+    assert std.isObject(value) : '"external_idp" expected to be of type "map"';
+
     {
-      external_idp: converted,
+      external_idp: value,
     }
   ),
+
   withExternalIdps(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"external_idps" expected to be of type "set"';
+
     {
       external_idps: converted,
     }
   ),
+
   withExternalIdpsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"external_idps" expected to be of type "set"';
+
     {
       external_idps+: converted,
     }
   ),
+
   withFidoU2f(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"fido_u2f" expected to be of type "map"';
+    assert std.isObject(value) : '"fido_u2f" expected to be of type "map"';
+
     {
-      fido_u2f: converted,
+      fido_u2f: value,
     }
   ),
+
   withFidoWebauthn(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"fido_webauthn" expected to be of type "map"';
+    assert std.isObject(value) : '"fido_webauthn" expected to be of type "map"';
+
     {
-      fido_webauthn: converted,
+      fido_webauthn: value,
     }
   ),
+
   withGoogleOtp(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"google_otp" expected to be of type "map"';
+    assert std.isObject(value) : '"google_otp" expected to be of type "map"';
+
     {
-      google_otp: converted,
+      google_otp: value,
     }
   ),
+
   withHotp(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"hotp" expected to be of type "map"';
+    assert std.isObject(value) : '"hotp" expected to be of type "map"';
+
     {
-      hotp: converted,
+      hotp: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIsOie":: "Is the policy using Okta Identity Engine (OIE) with authenticators instead of factors?",
   withIsOie(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"is_oie" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"is_oie" expected to be of type "bool"';
+
     {
-      is_oie: converted,
+      is_oie: value,
     }
   ),
+
   withOktaCall(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_call" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_call" expected to be of type "map"';
+
     {
-      okta_call: converted,
+      okta_call: value,
     }
   ),
+
   withOktaEmail(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_email" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_email" expected to be of type "map"';
+
     {
-      okta_email: converted,
+      okta_email: value,
     }
   ),
+
   withOktaOtp(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_otp" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_otp" expected to be of type "map"';
+
     {
-      okta_otp: converted,
+      okta_otp: value,
     }
   ),
+
   withOktaPassword(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_password" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_password" expected to be of type "map"';
+
     {
-      okta_password: converted,
+      okta_password: value,
     }
   ),
+
   withOktaPush(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_push" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_push" expected to be of type "map"';
+
     {
-      okta_push: converted,
+      okta_push: value,
     }
   ),
+
   withOktaQuestion(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_question" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_question" expected to be of type "map"';
+
     {
-      okta_question: converted,
+      okta_question: value,
     }
   ),
+
   withOktaSms(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_sms" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_sms" expected to be of type "map"';
+
     {
-      okta_sms: converted,
+      okta_sms: value,
     }
   ),
+
   withOktaVerify(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"okta_verify" expected to be of type "map"';
+    assert std.isObject(value) : '"okta_verify" expected to be of type "map"';
+
     {
-      okta_verify: converted,
+      okta_verify: value,
     }
   ),
+
   withOnpremMfa(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"onprem_mfa" expected to be of type "map"';
+    assert std.isObject(value) : '"onprem_mfa" expected to be of type "map"';
+
     {
-      onprem_mfa: converted,
+      onprem_mfa: value,
     }
   ),
+
   withPhoneNumber(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"phone_number" expected to be of type "map"';
+    assert std.isObject(value) : '"phone_number" expected to be of type "map"';
+
     {
-      phone_number: converted,
+      phone_number: value,
     }
   ),
+
   withRsaToken(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"rsa_token" expected to be of type "map"';
+    assert std.isObject(value) : '"rsa_token" expected to be of type "map"';
+
     {
-      rsa_token: converted,
+      rsa_token: value,
     }
   ),
+
   withSecurityQuestion(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"security_question" expected to be of type "map"';
+    assert std.isObject(value) : '"security_question" expected to be of type "map"';
+
     {
-      security_question: converted,
+      security_question: value,
     }
   ),
+
   withSmartCardIdp(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"smart_card_idp" expected to be of type "map"';
+    assert std.isObject(value) : '"smart_card_idp" expected to be of type "map"';
+
     {
-      smart_card_idp: converted,
+      smart_card_idp: value,
     }
   ),
+
   withSymantecVip(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"symantec_vip" expected to be of type "map"';
+    assert std.isObject(value) : '"symantec_vip" expected to be of type "map"';
+
     {
-      symantec_vip: converted,
+      symantec_vip: value,
     }
   ),
+
   withWebauthn(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"webauthn" expected to be of type "map"';
+    assert std.isObject(value) : '"webauthn" expected to be of type "map"';
+
     {
-      webauthn: converted,
+      webauthn: value,
     }
   ),
+
   withYubikeyToken(value):: (
-    local converted = value;
-    assert std.isObject(converted) : '"yubikey_token" expected to be of type "map"';
+    assert std.isObject(value) : '"yubikey_token" expected to be of type "map"';
+
     {
-      yubikey_token: converted,
+      yubikey_token: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_password.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_password.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,267 +14,304 @@
     }
     + block.withName(name)
   ),
+
   "#withAuthProvider":: "Authentication Provider: `OKTA`, `ACTIVE_DIRECTORY` or `LDAP`. Default: `OKTA`",
   withAuthProvider(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"auth_provider" expected to be of type "string"';
+    assert std.isString(value) : '"auth_provider" expected to be of type "string"';
+
     {
-      auth_provider: converted,
+      auth_provider: value,
     }
   ),
+
   "#withCallRecovery":: "Enable or disable voice call recovery: `ACTIVE` or `INACTIVE`. Default: `INACTIVE`",
   withCallRecovery(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"call_recovery" expected to be of type "string"';
+    assert std.isString(value) : '"call_recovery" expected to be of type "string"';
+
     {
-      call_recovery: converted,
+      call_recovery: value,
     }
   ),
+
   "#withDescription":: "Policy Description",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   "#withEmailRecovery":: "Enable or disable email password recovery: `ACTIVE` or `INACTIVE`. Default: `ACTIVE`",
   withEmailRecovery(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"email_recovery" expected to be of type "string"';
+    assert std.isString(value) : '"email_recovery" expected to be of type "string"';
+
     {
-      email_recovery: converted,
+      email_recovery: value,
     }
   ),
+
   "#withGroupsIncluded":: "List of Group IDs to Include",
   withGroupsIncluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_included" expected to be of type "set"';
+
     {
       groups_included: converted,
     }
   ),
+
   "#withGroupsIncludedMixin":: "List of Group IDs to Include",
   withGroupsIncludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_included" expected to be of type "set"';
+
     {
       groups_included+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Policy Name",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withPasswordAutoUnlockMinutes":: "Number of minutes before a locked account is unlocked: 0 = no limit. Default: `0`",
   withPasswordAutoUnlockMinutes(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_auto_unlock_minutes" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_auto_unlock_minutes" expected to be of type "number"';
+
     {
-      password_auto_unlock_minutes: converted,
+      password_auto_unlock_minutes: value,
     }
   ),
+
   "#withPasswordDictionaryLookup":: "Check Passwords Against Common Password Dictionary. Default: `false`",
   withPasswordDictionaryLookup(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"password_dictionary_lookup" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"password_dictionary_lookup" expected to be of type "bool"';
+
     {
-      password_dictionary_lookup: converted,
+      password_dictionary_lookup: value,
     }
   ),
+
   "#withPasswordExcludeFirstName":: "User firstName attribute must be excluded from the password",
   withPasswordExcludeFirstName(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"password_exclude_first_name" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"password_exclude_first_name" expected to be of type "bool"';
+
     {
-      password_exclude_first_name: converted,
+      password_exclude_first_name: value,
     }
   ),
+
   "#withPasswordExcludeLastName":: "User lastName attribute must be excluded from the password",
   withPasswordExcludeLastName(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"password_exclude_last_name" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"password_exclude_last_name" expected to be of type "bool"';
+
     {
-      password_exclude_last_name: converted,
+      password_exclude_last_name: value,
     }
   ),
+
   "#withPasswordExcludeUsername":: "If the user name must be excluded from the password. Default: `true`",
   withPasswordExcludeUsername(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"password_exclude_username" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"password_exclude_username" expected to be of type "bool"';
+
     {
-      password_exclude_username: converted,
+      password_exclude_username: value,
     }
   ),
+
   "#withPasswordExpireWarnDays":: "Length in days a user will be warned before password expiry: 0 = no warning. Default: `0`",
   withPasswordExpireWarnDays(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_expire_warn_days" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_expire_warn_days" expected to be of type "number"';
+
     {
-      password_expire_warn_days: converted,
+      password_expire_warn_days: value,
     }
   ),
+
   "#withPasswordHistoryCount":: "Number of distinct passwords that must be created before they can be reused: 0 = none. Default: `0`",
   withPasswordHistoryCount(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_history_count" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_history_count" expected to be of type "number"';
+
     {
-      password_history_count: converted,
+      password_history_count: value,
     }
   ),
+
   "#withPasswordLockoutNotificationChannels":: "Notification channels to use to notify a user when their account has been locked.",
   withPasswordLockoutNotificationChannels(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"password_lockout_notification_channels" expected to be of type "set"';
+
     {
       password_lockout_notification_channels: converted,
     }
   ),
+
   "#withPasswordLockoutNotificationChannelsMixin":: "Notification channels to use to notify a user when their account has been locked.",
   withPasswordLockoutNotificationChannelsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"password_lockout_notification_channels" expected to be of type "set"';
+
     {
       password_lockout_notification_channels+: converted,
     }
   ),
+
   "#withPasswordMaxAgeDays":: "Length in days a password is valid before expiry: 0 = no limit. Default: `0`",
   withPasswordMaxAgeDays(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_max_age_days" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_max_age_days" expected to be of type "number"';
+
     {
-      password_max_age_days: converted,
+      password_max_age_days: value,
     }
   ),
+
   "#withPasswordMaxLockoutAttempts":: "Number of unsuccessful login attempts allowed before lockout: 0 = no limit. Default: `10`",
   withPasswordMaxLockoutAttempts(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_max_lockout_attempts" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_max_lockout_attempts" expected to be of type "number"';
+
     {
-      password_max_lockout_attempts: converted,
+      password_max_lockout_attempts: value,
     }
   ),
+
   "#withPasswordMinAgeMinutes":: "Minimum time interval in minutes between password changes: 0 = no limit. Default: `0`",
   withPasswordMinAgeMinutes(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_min_age_minutes" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_min_age_minutes" expected to be of type "number"';
+
     {
-      password_min_age_minutes: converted,
+      password_min_age_minutes: value,
     }
   ),
+
   "#withPasswordMinLength":: "Minimum password length. Default: `8`",
   withPasswordMinLength(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_min_length" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_min_length" expected to be of type "number"';
+
     {
-      password_min_length: converted,
+      password_min_length: value,
     }
   ),
+
   "#withPasswordMinLowercase":: "If a password must contain at least one lower case letter: 0 = no, 1 = yes. Default: `1`",
   withPasswordMinLowercase(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_min_lowercase" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_min_lowercase" expected to be of type "number"';
+
     {
-      password_min_lowercase: converted,
+      password_min_lowercase: value,
     }
   ),
+
   "#withPasswordMinNumber":: "If a password must contain at least one number: 0 = no, 1 = yes. Default: `1`",
   withPasswordMinNumber(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_min_number" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_min_number" expected to be of type "number"';
+
     {
-      password_min_number: converted,
+      password_min_number: value,
     }
   ),
+
   "#withPasswordMinSymbol":: "If a password must contain at least one symbol (!@#$%^&*): 0 = no, 1 = yes. Default: `0`",
   withPasswordMinSymbol(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_min_symbol" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_min_symbol" expected to be of type "number"';
+
     {
-      password_min_symbol: converted,
+      password_min_symbol: value,
     }
   ),
+
   "#withPasswordMinUppercase":: "If a password must contain at least one upper case letter: 0 = no, 1 = yes. Default: `1`",
   withPasswordMinUppercase(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_min_uppercase" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_min_uppercase" expected to be of type "number"';
+
     {
-      password_min_uppercase: converted,
+      password_min_uppercase: value,
     }
   ),
+
   "#withPasswordShowLockoutFailures":: "If a user should be informed when their account is locked. Default: `false`",
   withPasswordShowLockoutFailures(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"password_show_lockout_failures" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"password_show_lockout_failures" expected to be of type "bool"';
+
     {
-      password_show_lockout_failures: converted,
+      password_show_lockout_failures: value,
     }
   ),
+
   "#withPriority":: "Policy Priority, this attribute can be set to a valid priority. To avoid endless diff situation we error if an invalid priority is provided. API defaults it to the last (lowest) if not there.",
   withPriority(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+    assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
     {
-      priority: converted,
+      priority: value,
     }
   ),
+
   "#withQuestionMinLength":: "Min length of the password recovery question answer. Default: `4`",
   withQuestionMinLength(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"question_min_length" expected to be of type "number"';
+    assert std.isNumber(value) : '"question_min_length" expected to be of type "number"';
+
     {
-      question_min_length: converted,
+      question_min_length: value,
     }
   ),
+
   "#withQuestionRecovery":: "Enable or disable security question password recovery: `ACTIVE` or `INACTIVE`. Default: `ACTIVE`",
   withQuestionRecovery(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"question_recovery" expected to be of type "string"';
+    assert std.isString(value) : '"question_recovery" expected to be of type "string"';
+
     {
-      question_recovery: converted,
+      question_recovery: value,
     }
   ),
+
   "#withRecoveryEmailToken":: "Lifetime in minutes of the recovery email token. Default: `60`",
   withRecoveryEmailToken(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"recovery_email_token" expected to be of type "number"';
+    assert std.isNumber(value) : '"recovery_email_token" expected to be of type "number"';
+
     {
-      recovery_email_token: converted,
+      recovery_email_token: value,
     }
   ),
+
   "#withSkipUnlock":: "When an Active Directory user is locked out of Okta, the Okta unlock operation should also attempt to unlock the user's Windows account. Default: `false`",
   withSkipUnlock(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"skip_unlock" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"skip_unlock" expected to be of type "bool"';
+
     {
-      skip_unlock: converted,
+      skip_unlock: value,
     }
   ),
+
   "#withSmsRecovery":: "Enable or disable SMS password recovery: `ACTIVE` or `INACTIVE`. Default: `INACTIVE`",
   withSmsRecovery(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"sms_recovery" expected to be of type "string"';
+    assert std.isString(value) : '"sms_recovery" expected to be of type "string"';
+
     {
-      sms_recovery: converted,
+      sms_recovery: value,
     }
   ),
+
   "#withStatus":: "Policy Status: `ACTIVE` or `INACTIVE`. Default: `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_password_default.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_password_default.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,211 +13,239 @@
       },
     }
   ),
+
   "#withCallRecovery":: "Enable or disable voice call recovery: ACTIVE or INACTIVE. Default: `INACTIVE`",
   withCallRecovery(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"call_recovery" expected to be of type "string"';
+    assert std.isString(value) : '"call_recovery" expected to be of type "string"';
+
     {
-      call_recovery: converted,
+      call_recovery: value,
     }
   ),
+
   "#withEmailRecovery":: "Enable or disable email password recovery: ACTIVE or INACTIVE. Default: `ACTIVE`",
   withEmailRecovery(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"email_recovery" expected to be of type "string"';
+    assert std.isString(value) : '"email_recovery" expected to be of type "string"';
+
     {
-      email_recovery: converted,
+      email_recovery: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withPasswordAutoUnlockMinutes":: "Number of minutes before a locked account is unlocked: 0 = no limit. Default: `0`",
   withPasswordAutoUnlockMinutes(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_auto_unlock_minutes" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_auto_unlock_minutes" expected to be of type "number"';
+
     {
-      password_auto_unlock_minutes: converted,
+      password_auto_unlock_minutes: value,
     }
   ),
+
   "#withPasswordDictionaryLookup":: "Check Passwords Against Common Password Dictionary. Default: `false`",
   withPasswordDictionaryLookup(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"password_dictionary_lookup" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"password_dictionary_lookup" expected to be of type "bool"';
+
     {
-      password_dictionary_lookup: converted,
+      password_dictionary_lookup: value,
     }
   ),
+
   "#withPasswordExcludeFirstName":: "User firstName attribute must be excluded from the password",
   withPasswordExcludeFirstName(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"password_exclude_first_name" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"password_exclude_first_name" expected to be of type "bool"';
+
     {
-      password_exclude_first_name: converted,
+      password_exclude_first_name: value,
     }
   ),
+
   "#withPasswordExcludeLastName":: "User lastName attribute must be excluded from the password",
   withPasswordExcludeLastName(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"password_exclude_last_name" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"password_exclude_last_name" expected to be of type "bool"';
+
     {
-      password_exclude_last_name: converted,
+      password_exclude_last_name: value,
     }
   ),
+
   "#withPasswordExcludeUsername":: "If the user name must be excluded from the password. Default: `true`",
   withPasswordExcludeUsername(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"password_exclude_username" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"password_exclude_username" expected to be of type "bool"';
+
     {
-      password_exclude_username: converted,
+      password_exclude_username: value,
     }
   ),
+
   "#withPasswordExpireWarnDays":: "Length in days a user will be warned before password expiry: 0 = no warning. Default: `0`",
   withPasswordExpireWarnDays(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_expire_warn_days" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_expire_warn_days" expected to be of type "number"';
+
     {
-      password_expire_warn_days: converted,
+      password_expire_warn_days: value,
     }
   ),
+
   "#withPasswordHistoryCount":: "Number of distinct passwords that must be created before they can be reused: 0 = none. Default: `4`",
   withPasswordHistoryCount(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_history_count" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_history_count" expected to be of type "number"';
+
     {
-      password_history_count: converted,
+      password_history_count: value,
     }
   ),
+
   "#withPasswordLockoutNotificationChannels":: "Notification channels to use to notify a user when their account has been locked.",
   withPasswordLockoutNotificationChannels(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"password_lockout_notification_channels" expected to be of type "set"';
+
     {
       password_lockout_notification_channels: converted,
     }
   ),
+
   "#withPasswordLockoutNotificationChannelsMixin":: "Notification channels to use to notify a user when their account has been locked.",
   withPasswordLockoutNotificationChannelsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"password_lockout_notification_channels" expected to be of type "set"';
+
     {
       password_lockout_notification_channels+: converted,
     }
   ),
+
   "#withPasswordMaxAgeDays":: "Length in days a password is valid before expiry: 0 = no limit. Default: `0`",
   withPasswordMaxAgeDays(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_max_age_days" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_max_age_days" expected to be of type "number"';
+
     {
-      password_max_age_days: converted,
+      password_max_age_days: value,
     }
   ),
+
   "#withPasswordMaxLockoutAttempts":: "Number of unsuccessful login attempts allowed before lockout: 0 = no limit. Default: `10`",
   withPasswordMaxLockoutAttempts(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_max_lockout_attempts" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_max_lockout_attempts" expected to be of type "number"';
+
     {
-      password_max_lockout_attempts: converted,
+      password_max_lockout_attempts: value,
     }
   ),
+
   "#withPasswordMinAgeMinutes":: "Minimum time interval in minutes between password changes: 0 = no limit. Default: `0`",
   withPasswordMinAgeMinutes(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_min_age_minutes" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_min_age_minutes" expected to be of type "number"';
+
     {
-      password_min_age_minutes: converted,
+      password_min_age_minutes: value,
     }
   ),
+
   "#withPasswordMinLength":: "Minimum password length. Default is `8`.",
   withPasswordMinLength(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_min_length" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_min_length" expected to be of type "number"';
+
     {
-      password_min_length: converted,
+      password_min_length: value,
     }
   ),
+
   "#withPasswordMinLowercase":: "If a password must contain at least one lower case letter: 0 = no, 1 = yes. Default = 1",
   withPasswordMinLowercase(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_min_lowercase" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_min_lowercase" expected to be of type "number"';
+
     {
-      password_min_lowercase: converted,
+      password_min_lowercase: value,
     }
   ),
+
   "#withPasswordMinNumber":: "If a password must contain at least one number: 0 = no, 1 = yes. Default = `1`",
   withPasswordMinNumber(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_min_number" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_min_number" expected to be of type "number"';
+
     {
-      password_min_number: converted,
+      password_min_number: value,
     }
   ),
+
   "#withPasswordMinSymbol":: "If a password must contain at least one symbol (!@#$%^&*): 0 = no, 1 = yes. Default = `0`",
   withPasswordMinSymbol(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_min_symbol" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_min_symbol" expected to be of type "number"';
+
     {
-      password_min_symbol: converted,
+      password_min_symbol: value,
     }
   ),
+
   "#withPasswordMinUppercase":: "If a password must contain at least one upper case letter: 0 = no, 1 = yes. Default = 1",
   withPasswordMinUppercase(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"password_min_uppercase" expected to be of type "number"';
+    assert std.isNumber(value) : '"password_min_uppercase" expected to be of type "number"';
+
     {
-      password_min_uppercase: converted,
+      password_min_uppercase: value,
     }
   ),
+
   "#withPasswordShowLockoutFailures":: "If a user should be informed when their account is locked. Default: `false`",
   withPasswordShowLockoutFailures(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"password_show_lockout_failures" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"password_show_lockout_failures" expected to be of type "bool"';
+
     {
-      password_show_lockout_failures: converted,
+      password_show_lockout_failures: value,
     }
   ),
+
   "#withQuestionMinLength":: "Min length of the password recovery question answer. Default: `4`",
   withQuestionMinLength(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"question_min_length" expected to be of type "number"';
+    assert std.isNumber(value) : '"question_min_length" expected to be of type "number"';
+
     {
-      question_min_length: converted,
+      question_min_length: value,
     }
   ),
+
   "#withQuestionRecovery":: "Enable or disable security question password recovery: ACTIVE or INACTIVE. Default: `ACTIVE`",
   withQuestionRecovery(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"question_recovery" expected to be of type "string"';
+    assert std.isString(value) : '"question_recovery" expected to be of type "string"';
+
     {
-      question_recovery: converted,
+      question_recovery: value,
     }
   ),
+
   "#withRecoveryEmailToken":: "Lifetime in minutes of the recovery email token. Default: `60`",
   withRecoveryEmailToken(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"recovery_email_token" expected to be of type "number"';
+    assert std.isNumber(value) : '"recovery_email_token" expected to be of type "number"';
+
     {
-      recovery_email_token: converted,
+      recovery_email_token: value,
     }
   ),
+
   "#withSkipUnlock":: "When an Active Directory user is locked out of Okta, the Okta unlock operation should also attempt to unlock the user's Windows account. Default: `false`",
   withSkipUnlock(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"skip_unlock" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"skip_unlock" expected to be of type "bool"';
+
     {
-      skip_unlock: converted,
+      skip_unlock: value,
     }
   ),
+
   "#withSmsRecovery":: "Enable or disable SMS password recovery: ACTIVE or INACTIVE. Default: `INACTIVE`",
   withSmsRecovery(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"sms_recovery" expected to be of type "string"';
+    assert std.isString(value) : '"sms_recovery" expected to be of type "string"';
+
     {
-      sms_recovery: converted,
+      sms_recovery: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_profile_enrollment.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_profile_enrollment.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,27 +14,30 @@
     }
     + block.withName(name)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Name of the policy",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withStatus":: "Status of the policy",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_profile_enrollment_apps.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_profile_enrollment_apps.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, policyId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,35 +14,41 @@
     }
     + block.withPolicyId(policyId)
   ),
+
   "#withApps":: "List of app IDs to be added to this policy",
   withApps(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"apps" expected to be of type "set"';
+
     {
       apps: converted,
     }
   ),
+
   "#withAppsMixin":: "List of app IDs to be added to this policy",
   withAppsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"apps" expected to be of type "set"';
+
     {
       apps+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withPolicyId":: "ID of the enrollment policy.",
   withPolicyId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"policy_id" expected to be of type "string"';
+    assert std.isString(value) : '"policy_id" expected to be of type "string"';
+
     {
-      policy_id: converted,
+      policy_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_rule_idp_discovery.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_rule_idp_discovery.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,99 +14,115 @@
     }
     + block.withName(name)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Policy Rule Name",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withNetworkConnection":: "Network selection mode: `ANYWHERE`, `ZONE`, `ON_NETWORK`, or `OFF_NETWORK`. Default: `ANYWHERE`",
   withNetworkConnection(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"network_connection" expected to be of type "string"';
+    assert std.isString(value) : '"network_connection" expected to be of type "string"';
+
     {
-      network_connection: converted,
+      network_connection: value,
     }
   ),
+
   "#withNetworkExcludes":: "Required if `network_connection` = `ZONE`. Indicates the network zones to exclude.",
   withNetworkExcludes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_excludes" expected to be of type "list"';
+
     {
       network_excludes: converted,
     }
   ),
+
   "#withNetworkExcludesMixin":: "Required if `network_connection` = `ZONE`. Indicates the network zones to exclude.",
   withNetworkExcludesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_excludes" expected to be of type "list"';
+
     {
       network_excludes+: converted,
     }
   ),
+
   "#withNetworkIncludes":: "Required if `network_connection` = `ZONE`. Indicates the network zones to include.",
   withNetworkIncludes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_includes" expected to be of type "list"';
+
     {
       network_includes: converted,
     }
   ),
+
   "#withNetworkIncludesMixin":: "Required if `network_connection` = `ZONE`. Indicates the network zones to include.",
   withNetworkIncludesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_includes" expected to be of type "list"';
+
     {
       network_includes+: converted,
     }
   ),
+
   "#withPolicyId":: "Policy ID of the Rule",
   withPolicyId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"policy_id" expected to be of type "string"';
+    assert std.isString(value) : '"policy_id" expected to be of type "string"';
+
     {
-      policy_id: converted,
+      policy_id: value,
     }
   ),
+
   "#withPriority":: "Rule priority. This attribute can be set to a valid priority. To avoid an endless diff situation an error is thrown if an invalid property is provided. The Okta API defaults to the last (lowest) if not provided.",
   withPriority(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+    assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
     {
-      priority: converted,
+      priority: value,
     }
   ),
+
   "#withStatus":: "Policy Rule Status: `ACTIVE` or `INACTIVE`. Default: `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withUserIdentifierAttribute":: "Profile attribute matching can only have a single value that describes the type indicated in `user_identifier_type`. This is the attribute or identifier that the `user_identifier_patterns` are checked against.",
   withUserIdentifierAttribute(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_identifier_attribute" expected to be of type "string"';
+    assert std.isString(value) : '"user_identifier_attribute" expected to be of type "string"';
+
     {
-      user_identifier_attribute: converted,
+      user_identifier_attribute: value,
     }
   ),
+
   "#withUserIdentifierType":: "One of: `IDENTIFIER`, `ATTRIBUTE`",
   withUserIdentifierType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_identifier_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_identifier_type" expected to be of type "string"';
+
     {
-      user_identifier_type: converted,
+      user_identifier_type: value,
     }
   ),
   withTerraformName(value):: {
@@ -115,160 +132,179 @@
       },
     },
   },
+
   appExclude:: {
     local block = self,
+
     new(type):: (
       {}
       + block.withType(type)
     ),
+
     withId(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"id" expected to be of type "string"';
+      assert std.isString(value) : '"id" expected to be of type "string"';
+
       {
-        id: converted,
+        id: value,
       }
     ),
+
     withName(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"name" expected to be of type "string"';
+      assert std.isString(value) : '"name" expected to be of type "string"';
+
       {
-        name: converted,
+        name: value,
       }
     ),
+
     withType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"type" expected to be of type "string"';
+      assert std.isString(value) : '"type" expected to be of type "string"';
+
       {
-        type: converted,
+        type: value,
       }
     ),
   },
   appInclude:: {
     local block = self,
+
     new(type):: (
       {}
       + block.withType(type)
     ),
+
     withId(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"id" expected to be of type "string"';
+      assert std.isString(value) : '"id" expected to be of type "string"';
+
       {
-        id: converted,
+        id: value,
       }
     ),
+
     withName(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"name" expected to be of type "string"';
+      assert std.isString(value) : '"name" expected to be of type "string"';
+
       {
-        name: converted,
+        name: value,
       }
     ),
+
     withType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"type" expected to be of type "string"';
+      assert std.isString(value) : '"type" expected to be of type "string"';
+
       {
-        type: converted,
+        type: value,
       }
     ),
   },
   idpProviders:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     "#withId":: "The identifier for the Idp the rule should route to if all conditions are met.",
     withId(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"id" expected to be of type "string"';
+      assert std.isString(value) : '"id" expected to be of type "string"';
+
       {
-        id: converted,
+        id: value,
       }
     ),
+
     "#withType":: "Type of IdP. One of: `AMAZON`, `APPLE`, `DISCORD`, `FACEBOOK`, `GITHUB`, `GITLAB`, `GOOGLE`, `IDV_CLEAR`, `IDV_INCODE`, `IDV_PERSONA`, `LINKEDIN`, `LOGINGOV`, `LOGINGOV_SANDBOX`, `MICROSOFT`, `OIDC`, `PAYPAL`, `PAYPAL_SANDBOX`, `SALESFORCE`, `SAML2`, `SPOTIFY`, `X509`, `XERO`, `YAHOO`, `YAHOOJP`, Default: `OKTA`",
     withType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"type" expected to be of type "string"';
+      assert std.isString(value) : '"type" expected to be of type "string"';
+
       {
-        type: converted,
+        type: value,
       }
     ),
   },
   platformInclude:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     "#withOsExpression":: "Only available with OTHER OS type",
     withOsExpression(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"os_expression" expected to be of type "string"';
+      assert std.isString(value) : '"os_expression" expected to be of type "string"';
+
       {
-        os_expression: converted,
+        os_expression: value,
       }
     ),
+
     withOsType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"os_type" expected to be of type "string"';
+      assert std.isString(value) : '"os_type" expected to be of type "string"';
+
       {
-        os_type: converted,
+        os_type: value,
       }
     ),
+
     withType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"type" expected to be of type "string"';
+      assert std.isString(value) : '"type" expected to be of type "string"';
+
       {
-        type: converted,
+        type: value,
       }
     ),
   },
   userIdentifierPatterns:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     withMatchType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"match_type" expected to be of type "string"';
+      assert std.isString(value) : '"match_type" expected to be of type "string"';
+
       {
-        match_type: converted,
+        match_type: value,
       }
     ),
+
     withValue(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"value" expected to be of type "string"';
+      assert std.isString(value) : '"value" expected to be of type "string"';
+
       {
-        value: converted,
+        value: value,
       }
     ),
   },
   withAppExclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      app_exclude: value,
+      app_exclude: converted,
     }
   ),
   withAppInclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      app_include: value,
+      app_include: converted,
     }
   ),
   withIdpProviders(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      idp_providers: value,
+      idp_providers: converted,
     }
   ),
   withPlatformInclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      platform_include: value,
+      platform_include: converted,
     }
   ),
   withUserIdentifierPatterns(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      user_identifier_patterns: value,
+      user_identifier_patterns: converted,
     }
   ),
   withAppExcludeMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_rule_mfa.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_rule_mfa.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,105 +14,124 @@
     }
     + block.withName(name)
   ),
+
   "#withEnroll":: "When a user should be prompted for MFA. It can be `CHALLENGE`, `LOGIN`, or `NEVER`.",
   withEnroll(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"enroll" expected to be of type "string"';
+    assert std.isString(value) : '"enroll" expected to be of type "string"';
+
     {
-      enroll: converted,
+      enroll: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Policy Rule Name",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withNetworkConnection":: "Network selection mode: `ANYWHERE`, `ZONE`, `ON_NETWORK`, or `OFF_NETWORK`. Default: `ANYWHERE`",
   withNetworkConnection(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"network_connection" expected to be of type "string"';
+    assert std.isString(value) : '"network_connection" expected to be of type "string"';
+
     {
-      network_connection: converted,
+      network_connection: value,
     }
   ),
+
   "#withNetworkExcludes":: "Required if `network_connection` = `ZONE`. Indicates the network zones to exclude.",
   withNetworkExcludes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_excludes" expected to be of type "list"';
+
     {
       network_excludes: converted,
     }
   ),
+
   "#withNetworkExcludesMixin":: "Required if `network_connection` = `ZONE`. Indicates the network zones to exclude.",
   withNetworkExcludesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_excludes" expected to be of type "list"';
+
     {
       network_excludes+: converted,
     }
   ),
+
   "#withNetworkIncludes":: "Required if `network_connection` = `ZONE`. Indicates the network zones to include.",
   withNetworkIncludes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_includes" expected to be of type "list"';
+
     {
       network_includes: converted,
     }
   ),
+
   "#withNetworkIncludesMixin":: "Required if `network_connection` = `ZONE`. Indicates the network zones to include.",
   withNetworkIncludesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_includes" expected to be of type "list"';
+
     {
       network_includes+: converted,
     }
   ),
+
   "#withPolicyId":: "Policy ID of the Rule",
   withPolicyId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"policy_id" expected to be of type "string"';
+    assert std.isString(value) : '"policy_id" expected to be of type "string"';
+
     {
-      policy_id: converted,
+      policy_id: value,
     }
   ),
+
   "#withPriority":: "Rule priority. This attribute can be set to a valid priority. To avoid an endless diff situation an error is thrown if an invalid property is provided. The Okta API defaults to the last (lowest) if not provided.",
   withPriority(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+    assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
     {
-      priority: converted,
+      priority: value,
     }
   ),
+
   "#withStatus":: "Policy Rule Status: `ACTIVE` or `INACTIVE`. Default: `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withUsersExcluded":: "Set of User IDs to Exclude",
   withUsersExcluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users_excluded" expected to be of type "set"';
+
     {
       users_excluded: converted,
     }
   ),
+
   "#withUsersExcludedMixin":: "Set of User IDs to Exclude",
   withUsersExcludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users_excluded" expected to be of type "set"';
+
     {
       users_excluded+: converted,
     }
@@ -123,72 +143,81 @@
       },
     },
   },
+
   appExclude:: {
     local block = self,
+
     new(type):: (
       {}
       + block.withType(type)
     ),
+
     withId(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"id" expected to be of type "string"';
+      assert std.isString(value) : '"id" expected to be of type "string"';
+
       {
-        id: converted,
+        id: value,
       }
     ),
+
     withName(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"name" expected to be of type "string"';
+      assert std.isString(value) : '"name" expected to be of type "string"';
+
       {
-        name: converted,
+        name: value,
       }
     ),
+
     withType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"type" expected to be of type "string"';
+      assert std.isString(value) : '"type" expected to be of type "string"';
+
       {
-        type: converted,
+        type: value,
       }
     ),
   },
   appInclude:: {
     local block = self,
+
     new(type):: (
       {}
       + block.withType(type)
     ),
+
     withId(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"id" expected to be of type "string"';
+      assert std.isString(value) : '"id" expected to be of type "string"';
+
       {
-        id: converted,
+        id: value,
       }
     ),
+
     withName(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"name" expected to be of type "string"';
+      assert std.isString(value) : '"name" expected to be of type "string"';
+
       {
-        name: converted,
+        name: value,
       }
     ),
+
     withType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"type" expected to be of type "string"';
+      assert std.isString(value) : '"type" expected to be of type "string"';
+
       {
-        type: converted,
+        type: value,
       }
     ),
   },
   withAppExclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      app_exclude: value,
+      app_exclude: converted,
     }
   ),
   withAppInclude(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      app_include: value,
+      app_include: converted,
     }
   ),
   withAppExcludeMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_rule_password.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_rule_password.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,121 +14,142 @@
     }
     + block.withName(name)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Policy Rule Name",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withNetworkConnection":: "Network selection mode: `ANYWHERE`, `ZONE`, `ON_NETWORK`, or `OFF_NETWORK`. Default: `ANYWHERE`",
   withNetworkConnection(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"network_connection" expected to be of type "string"';
+    assert std.isString(value) : '"network_connection" expected to be of type "string"';
+
     {
-      network_connection: converted,
+      network_connection: value,
     }
   ),
+
   "#withNetworkExcludes":: "Required if `network_connection` = `ZONE`. Indicates the network zones to exclude.",
   withNetworkExcludes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_excludes" expected to be of type "list"';
+
     {
       network_excludes: converted,
     }
   ),
+
   "#withNetworkExcludesMixin":: "Required if `network_connection` = `ZONE`. Indicates the network zones to exclude.",
   withNetworkExcludesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_excludes" expected to be of type "list"';
+
     {
       network_excludes+: converted,
     }
   ),
+
   "#withNetworkIncludes":: "Required if `network_connection` = `ZONE`. Indicates the network zones to include.",
   withNetworkIncludes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_includes" expected to be of type "list"';
+
     {
       network_includes: converted,
     }
   ),
+
   "#withNetworkIncludesMixin":: "Required if `network_connection` = `ZONE`. Indicates the network zones to include.",
   withNetworkIncludesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_includes" expected to be of type "list"';
+
     {
       network_includes+: converted,
     }
   ),
+
   "#withPasswordChange":: "Allow or deny a user to change their password: `ALLOW` or `DENY`. Default: `ALLOW`",
   withPasswordChange(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"password_change" expected to be of type "string"';
+    assert std.isString(value) : '"password_change" expected to be of type "string"';
+
     {
-      password_change: converted,
+      password_change: value,
     }
   ),
+
   "#withPasswordReset":: "Allow or deny a user to reset their password: `ALLOW` or `DENY`. Default: `ALLOW`",
   withPasswordReset(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"password_reset" expected to be of type "string"';
+    assert std.isString(value) : '"password_reset" expected to be of type "string"';
+
     {
-      password_reset: converted,
+      password_reset: value,
     }
   ),
+
   "#withPasswordUnlock":: "Allow or deny a user to unlock. Default: `DENY`",
   withPasswordUnlock(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"password_unlock" expected to be of type "string"';
+    assert std.isString(value) : '"password_unlock" expected to be of type "string"';
+
     {
-      password_unlock: converted,
+      password_unlock: value,
     }
   ),
+
   "#withPolicyId":: "Policy ID of the Rule",
   withPolicyId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"policy_id" expected to be of type "string"';
+    assert std.isString(value) : '"policy_id" expected to be of type "string"';
+
     {
-      policy_id: converted,
+      policy_id: value,
     }
   ),
+
   "#withPriority":: "Rule priority. This attribute can be set to a valid priority. To avoid an endless diff situation an error is thrown if an invalid property is provided. The Okta API defaults to the last (lowest) if not provided.",
   withPriority(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+    assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
     {
-      priority: converted,
+      priority: value,
     }
   ),
+
   "#withStatus":: "Policy Rule Status: `ACTIVE` or `INACTIVE`. Default: `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withUsersExcluded":: "Set of User IDs to Exclude",
   withUsersExcluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users_excluded" expected to be of type "set"';
+
     {
       users_excluded: converted,
     }
   ),
+
   "#withUsersExcludedMixin":: "Set of User IDs to Exclude",
   withUsersExcludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users_excluded" expected to be of type "set"';
+
     {
       users_excluded+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_rule_profile_enrollment.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_rule_profile_enrollment.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, policyId, unknownUserAction):: (
     {
       jsonnetTfMetadata:: {
@@ -14,91 +15,104 @@
     + block.withPolicyId(policyId)
     + block.withUnknownUserAction(unknownUserAction)
   ),
+
   "#withAccess":: "Allow or deny access based on the rule conditions. Valid values are: `ALLOW`, `DENY`. Default: `ALLOW`.",
   withAccess(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"access" expected to be of type "string"';
+    assert std.isString(value) : '"access" expected to be of type "string"';
+
     {
-      access: converted,
+      access: value,
     }
   ),
+
   "#withEmailVerification":: "Indicates whether email verification should occur before access is granted. Default: `true`.",
   withEmailVerification(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"email_verification" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"email_verification" expected to be of type "bool"';
+
     {
-      email_verification: converted,
+      email_verification: value,
     }
   ),
+
   "#withEnrollAuthenticatorTypes":: "Enrolls authenticator types",
   withEnrollAuthenticatorTypes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"enroll_authenticator_types" expected to be of type "set"';
+
     {
       enroll_authenticator_types: converted,
     }
   ),
+
   "#withEnrollAuthenticatorTypesMixin":: "Enrolls authenticator types",
   withEnrollAuthenticatorTypesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"enroll_authenticator_types" expected to be of type "set"';
+
     {
       enroll_authenticator_types+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withInlineHookId":: "ID of a Registration Inline Hook",
   withInlineHookId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"inline_hook_id" expected to be of type "string"';
+    assert std.isString(value) : '"inline_hook_id" expected to be of type "string"';
+
     {
-      inline_hook_id: converted,
+      inline_hook_id: value,
     }
   ),
+
   "#withPolicyId":: "ID of the policy",
   withPolicyId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"policy_id" expected to be of type "string"';
+    assert std.isString(value) : '"policy_id" expected to be of type "string"';
+
     {
-      policy_id: converted,
+      policy_id: value,
     }
   ),
+
   "#withProgressiveProfilingAction":: "Enabled or disabled progressive profiling action rule conditions: `ENABLED` or `DISABLED`. Default: `DISABLED`",
   withProgressiveProfilingAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"progressive_profiling_action" expected to be of type "string"';
+    assert std.isString(value) : '"progressive_profiling_action" expected to be of type "string"';
+
     {
-      progressive_profiling_action: converted,
+      progressive_profiling_action: value,
     }
   ),
+
   "#withTargetGroupId":: "The ID of a Group that this User should be added to",
   withTargetGroupId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"target_group_id" expected to be of type "string"';
+    assert std.isString(value) : '"target_group_id" expected to be of type "string"';
+
     {
-      target_group_id: converted,
+      target_group_id: value,
     }
   ),
+
   "#withUiSchemaId":: "Value created by the backend. If present all policy updates must include this attribute/value.",
   withUiSchemaId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"ui_schema_id" expected to be of type "string"';
+    assert std.isString(value) : '"ui_schema_id" expected to be of type "string"';
+
     {
-      ui_schema_id: converted,
+      ui_schema_id: value,
     }
   ),
+
   "#withUnknownUserAction":: "Which action should be taken if this User is new. Valid values are: `DENY`, `REGISTER`",
   withUnknownUserAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"unknown_user_action" expected to be of type "string"';
+    assert std.isString(value) : '"unknown_user_action" expected to be of type "string"';
+
     {
-      unknown_user_action: converted,
+      unknown_user_action: value,
     }
   ),
   withTerraformName(value):: {
@@ -108,42 +122,47 @@
       },
     },
   },
+
   profileAttributes:: {
     local block = self,
+
     new(label, name):: (
       {}
       + block.withLabel(label)
       + block.withName(name)
     ),
+
     "#withLabel":: "A display-friendly label for this property",
     withLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"label" expected to be of type "string"';
+      assert std.isString(value) : '"label" expected to be of type "string"';
+
       {
-        label: converted,
+        label: value,
       }
     ),
+
     "#withName":: "The name of a User Profile property",
     withName(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"name" expected to be of type "string"';
+      assert std.isString(value) : '"name" expected to be of type "string"';
+
       {
-        name: converted,
+        name: value,
       }
     ),
+
     "#withRequired":: "Indicates if this property is required for enrollment",
     withRequired(value):: (
-      local converted = value;
-      assert std.isBoolean(converted) : '"required" expected to be of type "bool"';
+      assert std.isBoolean(value) : '"required" expected to be of type "bool"';
+
       {
-        required: converted,
+        required: value,
       }
     ),
   },
   withProfileAttributes(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      profile_attributes: value,
+      profile_attributes: converted,
     }
   ),
   withProfileAttributesMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_rule_signon.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_rule_signon.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,233 +14,272 @@
     }
     + block.withName(name)
   ),
+
   "#withAccess":: "Allow or deny access based on the rule conditions: `ALLOW`, `DENY` or `CHALLENGE`. Default: `ALLOW`",
   withAccess(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"access" expected to be of type "string"';
+    assert std.isString(value) : '"access" expected to be of type "string"';
+
     {
-      access: converted,
+      access: value,
     }
   ),
+
   "#withAuthtype":: "Authentication entrypoint: `ANY`, `RADIUS` or `LDAP_INTERFACE`. Default: `ANY`",
   withAuthtype(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"authtype" expected to be of type "string"';
+    assert std.isString(value) : '"authtype" expected to be of type "string"';
+
     {
-      authtype: converted,
+      authtype: value,
     }
   ),
+
   "#withBehaviors":: "List of behavior IDs",
   withBehaviors(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"behaviors" expected to be of type "set"';
+
     {
       behaviors: converted,
     }
   ),
+
   "#withBehaviorsMixin":: "List of behavior IDs",
   withBehaviorsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"behaviors" expected to be of type "set"';
+
     {
       behaviors+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIdentityProvider":: "Apply rule based on the IdP used: `ANY`, `OKTA` or `SPECIFIC_IDP`. Default: `ANY`. ~> **WARNING**: Use of `identity_provider` requires a feature flag to be enabled.",
   withIdentityProvider(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"identity_provider" expected to be of type "string"';
+    assert std.isString(value) : '"identity_provider" expected to be of type "string"';
+
     {
-      identity_provider: converted,
+      identity_provider: value,
     }
   ),
+
   "#withIdentityProviderIds":: "When identity_provider is `SPECIFIC_IDP` then this is the list of IdP IDs to apply the rule on",
   withIdentityProviderIds(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"identity_provider_ids" expected to be of type "list"';
+
     {
       identity_provider_ids: converted,
     }
   ),
+
   "#withIdentityProviderIdsMixin":: "When identity_provider is `SPECIFIC_IDP` then this is the list of IdP IDs to apply the rule on",
   withIdentityProviderIdsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"identity_provider_ids" expected to be of type "list"';
+
     {
       identity_provider_ids+: converted,
     }
   ),
+
   "#withMfaLifetime":: "Elapsed time before the next MFA challenge",
   withMfaLifetime(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"mfa_lifetime" expected to be of type "number"';
+    assert std.isNumber(value) : '"mfa_lifetime" expected to be of type "number"';
+
     {
-      mfa_lifetime: converted,
+      mfa_lifetime: value,
     }
   ),
+
   "#withMfaPrompt":: "Prompt for MFA based on the device used, a factor session lifetime, or every sign-on attempt: `DEVICE`, `SESSION` or`ALWAYS`.",
   withMfaPrompt(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"mfa_prompt" expected to be of type "string"';
+    assert std.isString(value) : '"mfa_prompt" expected to be of type "string"';
+
     {
-      mfa_prompt: converted,
+      mfa_prompt: value,
     }
   ),
+
   "#withMfaRememberDevice":: "Remember MFA device. Default: `false`",
   withMfaRememberDevice(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"mfa_remember_device" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"mfa_remember_device" expected to be of type "bool"';
+
     {
-      mfa_remember_device: converted,
+      mfa_remember_device: value,
     }
   ),
+
   "#withMfaRequired":: "Require MFA. Default: `false`",
   withMfaRequired(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"mfa_required" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"mfa_required" expected to be of type "bool"';
+
     {
-      mfa_required: converted,
+      mfa_required: value,
     }
   ),
+
   "#withName":: "Policy Rule Name",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withNetworkConnection":: "Network selection mode: `ANYWHERE`, `ZONE`, `ON_NETWORK`, or `OFF_NETWORK`. Default: `ANYWHERE`",
   withNetworkConnection(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"network_connection" expected to be of type "string"';
+    assert std.isString(value) : '"network_connection" expected to be of type "string"';
+
     {
-      network_connection: converted,
+      network_connection: value,
     }
   ),
+
   "#withNetworkExcludes":: "Required if `network_connection` = `ZONE`. Indicates the network zones to exclude.",
   withNetworkExcludes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_excludes" expected to be of type "list"';
+
     {
       network_excludes: converted,
     }
   ),
+
   "#withNetworkExcludesMixin":: "Required if `network_connection` = `ZONE`. Indicates the network zones to exclude.",
   withNetworkExcludesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_excludes" expected to be of type "list"';
+
     {
       network_excludes+: converted,
     }
   ),
+
   "#withNetworkIncludes":: "Required if `network_connection` = `ZONE`. Indicates the network zones to include.",
   withNetworkIncludes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_includes" expected to be of type "list"';
+
     {
       network_includes: converted,
     }
   ),
+
   "#withNetworkIncludesMixin":: "Required if `network_connection` = `ZONE`. Indicates the network zones to include.",
   withNetworkIncludesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_includes" expected to be of type "list"';
+
     {
       network_includes+: converted,
     }
   ),
+
   "#withPolicyId":: "Policy ID of the Rule",
   withPolicyId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"policy_id" expected to be of type "string"';
+    assert std.isString(value) : '"policy_id" expected to be of type "string"';
+
     {
-      policy_id: converted,
+      policy_id: value,
     }
   ),
+
   "#withPrimaryFactor":: "Rule's primary factor. **WARNING** Ony works as a part of the Identity Engine. Valid values: `PASSWORD_IDP_ANY_FACTOR`, `PASSWORD_IDP`.",
   withPrimaryFactor(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"primary_factor" expected to be of type "string"';
+    assert std.isString(value) : '"primary_factor" expected to be of type "string"';
+
     {
-      primary_factor: converted,
+      primary_factor: value,
     }
   ),
+
   "#withPriority":: "Rule priority. This attribute can be set to a valid priority. To avoid an endless diff situation an error is thrown if an invalid property is provided. The Okta API defaults to the last (lowest) if not provided.",
   withPriority(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+    assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
     {
-      priority: converted,
+      priority: value,
     }
   ),
+
   "#withRiscLevel":: "Risc level: ANY, LOW, MEDIUM or HIGH. Default: `ANY`",
   withRiscLevel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"risc_level" expected to be of type "string"';
+    assert std.isString(value) : '"risc_level" expected to be of type "string"';
+
     {
-      risc_level: converted,
+      risc_level: value,
     }
   ),
+
   "#withRiskLevel":: "Risk level: ANY, LOW, MEDIUM or HIGH. Default: `ANY`",
   withRiskLevel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"risk_level" expected to be of type "string"';
+    assert std.isString(value) : '"risk_level" expected to be of type "string"';
+
     {
-      risk_level: converted,
+      risk_level: value,
     }
   ),
+
   "#withSessionIdle":: "Max minutes a session can be idle. Default: `120`",
   withSessionIdle(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"session_idle" expected to be of type "number"';
+    assert std.isNumber(value) : '"session_idle" expected to be of type "number"';
+
     {
-      session_idle: converted,
+      session_idle: value,
     }
   ),
+
   "#withSessionLifetime":: "Max minutes a session is active: Disable = 0. Default: `120`",
   withSessionLifetime(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"session_lifetime" expected to be of type "number"';
+    assert std.isNumber(value) : '"session_lifetime" expected to be of type "number"';
+
     {
-      session_lifetime: converted,
+      session_lifetime: value,
     }
   ),
+
   "#withSessionPersistent":: "Whether session cookies will last across browser sessions. Okta Administrators can never have persistent session cookies. Default: `false`",
   withSessionPersistent(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"session_persistent" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"session_persistent" expected to be of type "bool"';
+
     {
-      session_persistent: converted,
+      session_persistent: value,
     }
   ),
+
   "#withStatus":: "Policy Rule Status: `ACTIVE` or `INACTIVE`. Default: `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withUsersExcluded":: "Set of User IDs to Exclude",
   withUsersExcluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users_excluded" expected to be of type "set"';
+
     {
       users_excluded: converted,
     }
   ),
+
   "#withUsersExcludedMixin":: "Set of User IDs to Exclude",
   withUsersExcludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"users_excluded" expected to be of type "set"';
+
     {
       users_excluded+: converted,
     }
@@ -251,57 +291,65 @@
       },
     },
   },
+
   factorSequence:: {
     local block = self,
+
     new(primaryCriteriaFactorType, primaryCriteriaProvider):: (
       {}
       + block.withPrimaryCriteriaFactorType(primaryCriteriaFactorType)
       + block.withPrimaryCriteriaProvider(primaryCriteriaProvider)
     ),
+
     "#withPrimaryCriteriaFactorType":: "Type of a Factor",
     withPrimaryCriteriaFactorType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"primary_criteria_factor_type" expected to be of type "string"';
+      assert std.isString(value) : '"primary_criteria_factor_type" expected to be of type "string"';
+
       {
-        primary_criteria_factor_type: converted,
+        primary_criteria_factor_type: value,
       }
     ),
+
     "#withPrimaryCriteriaProvider":: "Factor provider",
     withPrimaryCriteriaProvider(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"primary_criteria_provider" expected to be of type "string"';
+      assert std.isString(value) : '"primary_criteria_provider" expected to be of type "string"';
+
       {
-        primary_criteria_provider: converted,
+        primary_criteria_provider: value,
       }
     ),
+
     secondaryCriteria:: {
       local block = self,
+
       new(factorType, provider):: (
         {}
         + block.withFactorType(factorType)
         + block.withProvider(provider)
       ),
+
       "#withFactorType":: "Type of a Factor",
       withFactorType(value):: (
-        local converted = value;
-        assert std.isString(converted) : '"factor_type" expected to be of type "string"';
+        assert std.isString(value) : '"factor_type" expected to be of type "string"';
+
         {
-          factor_type: converted,
+          factor_type: value,
         }
       ),
+
       "#withProvider":: "Factor provider",
       withProvider(value):: (
-        local converted = value;
-        assert std.isString(converted) : '"provider" expected to be of type "string"';
+        assert std.isString(value) : '"provider" expected to be of type "string"';
+
         {
-          provider: converted,
+          provider: value,
         }
       ),
     },
     withSecondaryCriteria(value):: (
       local converted = if std.isArray(value) then value else [value];
       {
-        secondary_criteria: value,
+        secondary_criteria: converted,
       }
     ),
     withSecondaryCriteriaMixin(value):: (
@@ -314,7 +362,7 @@
   withFactorSequence(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      factor_sequence: value,
+      factor_sequence: converted,
     }
   ),
   withFactorSequenceMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_signon.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_policy_signon.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -13,59 +14,68 @@
     }
     + block.withName(name)
   ),
+
   "#withDescription":: "Policy Description",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   "#withGroupsIncluded":: "List of Group IDs to Include",
   withGroupsIncluded(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_included" expected to be of type "set"';
+
     {
       groups_included: converted,
     }
   ),
+
   "#withGroupsIncludedMixin":: "List of Group IDs to Include",
   withGroupsIncludedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups_included" expected to be of type "set"';
+
     {
       groups_included+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Policy Name",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withPriority":: "Policy Priority, this attribute can be set to a valid priority. To avoid endless diff situation we error if an invalid priority is provided. API defaults it to the last (lowest) if not there.",
   withPriority(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+    assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
     {
-      priority: converted,
+      priority: value,
     }
   ),
+
   "#withStatus":: "Policy Status: `ACTIVE` or `INACTIVE`. Default: `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_preview_signin_page.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_preview_signin_page.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId, pageContent, widgetVersion):: (
     {
       jsonnetTfMetadata:: {
@@ -15,28 +16,31 @@
     + block.withPageContent(pageContent)
     + block.withWidgetVersion(widgetVersion)
   ),
+
   "#withBrandId":: "brand id of the preview signin page",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   "#withPageContent":: "page content of the preview signin page",
   withPageContent(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"page_content" expected to be of type "string"';
+    assert std.isString(value) : '"page_content" expected to be of type "string"';
+
     {
-      page_content: converted,
+      page_content: value,
     }
   ),
+
   "#withWidgetVersion":: "widget version specified as a Semver. The following are currently supported \t\t\t*, ^1, ^2, ^3, ^4, ^5, ^6, ^7, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 2.1, 2.2, 2.3, 2.4, \t\t\t2.5, 2.6, 2.7, 2.8, 2.9, 2.10, 2.11, 2.12, 2.13, 2.14, 2.15, 2.16, 2.17, 2.18, 2.19, 2.20, 2.21, \t\t\t3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 5.0, 5.1, 5.2, 5.3, \t\t\t5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 5.10, 5.11, 5.12, 5.13, 5.14, 5.15, 5.16, 6.0, 6.1, 6.2, 6.3, 6.4, 6.5, \t\t\t6.6, 6.7, 6.8, 6.9, 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 7.10, 7.11, 7.12, 7.13.",
   withWidgetVersion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"widget_version" expected to be of type "string"';
+    assert std.isString(value) : '"widget_version" expected to be of type "string"';
+
     {
-      widget_version: converted,
+      widget_version: value,
     }
   ),
   withTerraformName(value):: {
@@ -46,36 +50,44 @@
       },
     },
   },
+
   contentSecurityPolicySetting:: {
     local block = self,
+
     new():: (
       {}
     ),
+
     "#withMode":: "enforced or report_only",
     withMode(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"mode" expected to be of type "string"';
+      assert std.isString(value) : '"mode" expected to be of type "string"';
+
       {
-        mode: converted,
+        mode: value,
       }
     ),
+
     withReportUri(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"report_uri" expected to be of type "string"';
+      assert std.isString(value) : '"report_uri" expected to be of type "string"';
+
       {
-        report_uri: converted,
+        report_uri: value,
       }
     ),
+
     withSrcList(value):: (
       local converted = if std.isArray(value) then value else [value];
       assert std.isArray(converted) : '"src_list" expected to be of type "list"';
+
       {
         src_list: converted,
       }
     ),
+
     withSrcListMixin(value):: (
       local converted = if std.isArray(value) then value else [value];
       assert std.isArray(converted) : '"src_list" expected to be of type "list"';
+
       {
         src_list+: converted,
       }
@@ -83,166 +95,186 @@
   },
   widgetCustomizations:: {
     local block = self,
+
     new(widgetGeneration):: (
       {}
       + block.withWidgetGeneration(widgetGeneration)
     ),
+
     withAuthenticatorPageCustomLinkLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"authenticator_page_custom_link_label" expected to be of type "string"';
+      assert std.isString(value) : '"authenticator_page_custom_link_label" expected to be of type "string"';
+
       {
-        authenticator_page_custom_link_label: converted,
+        authenticator_page_custom_link_label: value,
       }
     ),
+
     withAuthenticatorPageCustomLinkUrl(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"authenticator_page_custom_link_url" expected to be of type "string"';
+      assert std.isString(value) : '"authenticator_page_custom_link_url" expected to be of type "string"';
+
       {
-        authenticator_page_custom_link_url: converted,
+        authenticator_page_custom_link_url: value,
       }
     ),
+
     withClassicRecoveryFlowEmailOrUsernameLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"classic_recovery_flow_email_or_username_label" expected to be of type "string"';
+      assert std.isString(value) : '"classic_recovery_flow_email_or_username_label" expected to be of type "string"';
+
       {
-        classic_recovery_flow_email_or_username_label: converted,
+        classic_recovery_flow_email_or_username_label: value,
       }
     ),
+
     withCustomLink_1Label(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"custom_link_1_label" expected to be of type "string"';
+      assert std.isString(value) : '"custom_link_1_label" expected to be of type "string"';
+
       {
-        custom_link_1_label: converted,
+        custom_link_1_label: value,
       }
     ),
+
     withCustomLink_1Url(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"custom_link_1_url" expected to be of type "string"';
+      assert std.isString(value) : '"custom_link_1_url" expected to be of type "string"';
+
       {
-        custom_link_1_url: converted,
+        custom_link_1_url: value,
       }
     ),
+
     withCustomLink_2Label(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"custom_link_2_label" expected to be of type "string"';
+      assert std.isString(value) : '"custom_link_2_label" expected to be of type "string"';
+
       {
-        custom_link_2_label: converted,
+        custom_link_2_label: value,
       }
     ),
+
     withCustomLink_2Url(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"custom_link_2_url" expected to be of type "string"';
+      assert std.isString(value) : '"custom_link_2_url" expected to be of type "string"';
+
       {
-        custom_link_2_url: converted,
+        custom_link_2_url: value,
       }
     ),
+
     withForgotPasswordLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"forgot_password_label" expected to be of type "string"';
+      assert std.isString(value) : '"forgot_password_label" expected to be of type "string"';
+
       {
-        forgot_password_label: converted,
+        forgot_password_label: value,
       }
     ),
+
     withForgotPasswordUrl(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"forgot_password_url" expected to be of type "string"';
+      assert std.isString(value) : '"forgot_password_url" expected to be of type "string"';
+
       {
-        forgot_password_url: converted,
+        forgot_password_url: value,
       }
     ),
+
     withHelpLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"help_label" expected to be of type "string"';
+      assert std.isString(value) : '"help_label" expected to be of type "string"';
+
       {
-        help_label: converted,
+        help_label: value,
       }
     ),
+
     withHelpUrl(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"help_url" expected to be of type "string"';
+      assert std.isString(value) : '"help_url" expected to be of type "string"';
+
       {
-        help_url: converted,
+        help_url: value,
       }
     ),
+
     withPasswordInfoTip(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"password_info_tip" expected to be of type "string"';
+      assert std.isString(value) : '"password_info_tip" expected to be of type "string"';
+
       {
-        password_info_tip: converted,
+        password_info_tip: value,
       }
     ),
+
     withPasswordLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"password_label" expected to be of type "string"';
+      assert std.isString(value) : '"password_label" expected to be of type "string"';
+
       {
-        password_label: converted,
+        password_label: value,
       }
     ),
+
     withShowPasswordVisibilityToggle(value):: (
-      local converted = value;
-      assert std.isBoolean(converted) : '"show_password_visibility_toggle" expected to be of type "bool"';
+      assert std.isBoolean(value) : '"show_password_visibility_toggle" expected to be of type "bool"';
+
       {
-        show_password_visibility_toggle: converted,
+        show_password_visibility_toggle: value,
       }
     ),
+
     withShowUserIdentifier(value):: (
-      local converted = value;
-      assert std.isBoolean(converted) : '"show_user_identifier" expected to be of type "bool"';
+      assert std.isBoolean(value) : '"show_user_identifier" expected to be of type "bool"';
+
       {
-        show_user_identifier: converted,
+        show_user_identifier: value,
       }
     ),
+
     withSignInLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"sign_in_label" expected to be of type "string"';
+      assert std.isString(value) : '"sign_in_label" expected to be of type "string"';
+
       {
-        sign_in_label: converted,
+        sign_in_label: value,
       }
     ),
+
     withUnlockAccountLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"unlock_account_label" expected to be of type "string"';
+      assert std.isString(value) : '"unlock_account_label" expected to be of type "string"';
+
       {
-        unlock_account_label: converted,
+        unlock_account_label: value,
       }
     ),
+
     withUnlockAccountUrl(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"unlock_account_url" expected to be of type "string"';
+      assert std.isString(value) : '"unlock_account_url" expected to be of type "string"';
+
       {
-        unlock_account_url: converted,
+        unlock_account_url: value,
       }
     ),
+
     withUsernameInfoTip(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"username_info_tip" expected to be of type "string"';
+      assert std.isString(value) : '"username_info_tip" expected to be of type "string"';
+
       {
-        username_info_tip: converted,
+        username_info_tip: value,
       }
     ),
+
     withUsernameLabel(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"username_label" expected to be of type "string"';
+      assert std.isString(value) : '"username_label" expected to be of type "string"';
+
       {
-        username_label: converted,
+        username_label: value,
       }
     ),
+
     withWidgetGeneration(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"widget_generation" expected to be of type "string"';
+      assert std.isString(value) : '"widget_generation" expected to be of type "string"';
+
       {
-        widget_generation: converted,
+        widget_generation: value,
       }
     ),
   },
   withContentSecurityPolicySetting(value):: (
-    local converted = value;
     {
       content_security_policy_setting: value,
     }
   ),
   withWidgetCustomizations(value):: (
-    local converted = value;
     {
       widget_customizations: value,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_profile_mapping.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_profile_mapping.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, sourceId, targetId):: (
     {
       jsonnetTfMetadata:: {
@@ -14,43 +15,48 @@
     + block.withSourceId(sourceId)
     + block.withTargetId(targetId)
   ),
+
   "#withAlwaysApply":: "Whether apply the changes to all users with this profile after updating or creating the these mappings.  \t~> **WARNING:**: 'always_apply' is incompatible with OAuth 2.0 authentication and will be ignored when using that type of authentication. \t~> **WARNING:** 'always_apply' makes use of an internal/private Okta API endpoint that could change without notice rendering this resource inoperable.",
   withAlwaysApply(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"always_apply" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"always_apply" expected to be of type "bool"';
+
     {
-      always_apply: converted,
+      always_apply: value,
     }
   ),
+
   "#withDeleteWhenAbsent":: "When turned on this flag will trigger the provider to delete mapping properties that are not defined in config. By default, we do not delete missing properties.",
   withDeleteWhenAbsent(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"delete_when_absent" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"delete_when_absent" expected to be of type "bool"';
+
     {
-      delete_when_absent: converted,
+      delete_when_absent: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withSourceId":: "The source id of the mapping to manage.",
   withSourceId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"source_id" expected to be of type "string"';
+    assert std.isString(value) : '"source_id" expected to be of type "string"';
+
     {
-      source_id: converted,
+      source_id: value,
     }
   ),
+
   "#withTargetId":: "The target id of the mapping to manage.",
   withTargetId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"target_id" expected to be of type "string"';
+    assert std.isString(value) : '"target_id" expected to be of type "string"';
+
     {
-      target_id: converted,
+      target_id: value,
     }
   ),
   withTerraformName(value):: {
@@ -60,40 +66,45 @@
       },
     },
   },
+
   mappings:: {
     local block = self,
+
     new(expression, id):: (
       {}
       + block.withExpression(expression)
       + block.withId(id)
     ),
+
     withExpression(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"expression" expected to be of type "string"';
+      assert std.isString(value) : '"expression" expected to be of type "string"';
+
       {
-        expression: converted,
+        expression: value,
       }
     ),
+
     "#withId":: "The mapping property key.",
     withId(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"id" expected to be of type "string"';
+      assert std.isString(value) : '"id" expected to be of type "string"';
+
       {
-        id: converted,
+        id: value,
       }
     ),
+
     withPushStatus(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"push_status" expected to be of type "string"';
+      assert std.isString(value) : '"push_status" expected to be of type "string"';
+
       {
-        push_status: converted,
+        push_status: value,
       }
     ),
   },
   withMappings(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      mappings: value,
+      mappings: converted,
     }
   ),
   withMappingsMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_rate_limiting.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_rate_limiting.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, authorize, login):: (
     {
       jsonnetTfMetadata:: {
@@ -14,35 +15,39 @@
     + block.withAuthorize(authorize)
     + block.withLogin(login)
   ),
+
   "#withAuthorize":: "Called during authentication. Valid values: `ENFORCE` _(Enforce limit and log per client (recommended))_, `DISABLE` _(Do nothing (not recommended))_, `PREVIEW` _(Log per client)_.",
   withAuthorize(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"authorize" expected to be of type "string"';
+    assert std.isString(value) : '"authorize" expected to be of type "string"';
+
     {
-      authorize: converted,
+      authorize: value,
     }
   ),
+
   "#withCommunicationsEnabled":: "Enable or disable rate limiting communications. By default, it is `true`.",
   withCommunicationsEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"communications_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"communications_enabled" expected to be of type "bool"';
+
     {
-      communications_enabled: converted,
+      communications_enabled: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLogin":: "Called when accessing the Okta hosted login page. Valid values: `ENFORCE` _(Enforce limit and log per client (recommended))_, `DISABLE` _(Do nothing (not recommended))_, `PREVIEW` _(Log per client)_.",
   withLogin(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"login" expected to be of type "string"';
+    assert std.isString(value) : '"login" expected to be of type "string"';
+
     {
-      login: converted,
+      login: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_realm.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_realm.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name, realmType):: (
     {
       jsonnetTfMetadata:: {
@@ -14,20 +15,22 @@
     + block.withName(name)
     + block.withRealmType(realmType)
   ),
+
   "#withName":: "The name of the Okta Realm.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withRealmType":: "The realm type. Valid values: `PARTNER` and `DEFAULT`",
   withRealmType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"realm_type" expected to be of type "string"';
+    assert std.isString(value) : '"realm_type" expected to be of type "string"';
+
     {
-      realm_type: converted,
+      realm_type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_realm_assignment.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_realm_assignment.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name, profileSourceId, realmId):: (
     {
       jsonnetTfMetadata:: {
@@ -15,52 +16,58 @@
     + block.withProfileSourceId(profileSourceId)
     + block.withRealmId(realmId)
   ),
+
   "#withConditionExpression":: "Condition expression for the Realm Assignment in Okta Expression Language. Example: `user.profile.role =='Manager'` or `user.profile.state.contains('example')`.",
   withConditionExpression(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"condition_expression" expected to be of type "string"';
+    assert std.isString(value) : '"condition_expression" expected to be of type "string"';
+
     {
-      condition_expression: converted,
+      condition_expression: value,
     }
   ),
+
   "#withName":: "The name of the Okta Realm Assignment.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withPriority":: "The Priority of the Realm Assignment. The lower the number, the higher the priority.",
   withPriority(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"priority" expected to be of type "number"';
+    assert std.isNumber(value) : '"priority" expected to be of type "number"';
+
     {
-      priority: converted,
+      priority: value,
     }
   ),
+
   "#withProfileSourceId":: "The ID of the Profile Source.",
   withProfileSourceId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"profile_source_id" expected to be of type "string"';
+    assert std.isString(value) : '"profile_source_id" expected to be of type "string"';
+
     {
-      profile_source_id: converted,
+      profile_source_id: value,
     }
   ),
+
   "#withRealmId":: "The ID of the Realm asscociated with the Realm Assignment.",
   withRealmId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"realm_id" expected to be of type "string"';
+    assert std.isString(value) : '"realm_id" expected to be of type "string"';
+
     {
-      realm_id: converted,
+      realm_id: value,
     }
   ),
+
   "#withStatus":: "Defines whether the Realm Assignment is active or not. Valid values: `ACTIVE` and `INACTIVE`.",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_resource_set.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_resource_set.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, description, label):: (
     {
       jsonnetTfMetadata:: {
@@ -14,57 +15,68 @@
     + block.withDescription(description)
     + block.withLabel(label)
   ),
+
   "#withDescription":: "A description of the Resource Set",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLabel":: "Unique name given to the Resource Set",
   withLabel(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"label" expected to be of type "string"';
+    assert std.isString(value) : '"label" expected to be of type "string"';
+
     {
-      label: converted,
+      label: value,
     }
   ),
+
   "#withResources":: "The endpoints that reference the resources to be included in the new Resource Set. At least one endpoint must be specified when creating resource set. Only one of 'resources' or 'resources_orn' can be specified.",
   withResources(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"resources" expected to be of type "set"';
+
     {
       resources: converted,
     }
   ),
+
   "#withResourcesMixin":: "The endpoints that reference the resources to be included in the new Resource Set. At least one endpoint must be specified when creating resource set. Only one of 'resources' or 'resources_orn' can be specified.",
   withResourcesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"resources" expected to be of type "set"';
+
     {
       resources+: converted,
     }
   ),
+
   "#withResourcesOrn":: "The orn(Okta Resource Name) that reference the resources to be included in the new Resource Set. At least one orn must be specified when creating resource set. Only one of 'resources' or 'resources_orn' can be specified.",
   withResourcesOrn(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"resources_orn" expected to be of type "set"';
+
     {
       resources_orn: converted,
     }
   ),
+
   "#withResourcesOrnMixin":: "The orn(Okta Resource Name) that reference the resources to be included in the new Resource Set. At least one orn must be specified when creating resource set. Only one of 'resources' or 'resources_orn' can be specified.",
   withResourcesOrnMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"resources_orn" expected to be of type "set"';
+
     {
       resources_orn+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_role_subscription.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_role_subscription.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, notificationType, roleType):: (
     {
       jsonnetTfMetadata:: {
@@ -14,35 +15,39 @@
     + block.withNotificationType(notificationType)
     + block.withRoleType(roleType)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withNotificationType":: "Type of the notification. Valid values:  \t- 'CONNECTOR_AGENT' -  Disconnects and reconnects: On-prem provisioning, on-prem MFA agents, and RADIUS server agent. \t- 'USER_LOCKED_OUT' - User lockouts. \t- 'APP_IMPORT' - App user import status. \t- 'LDAP_AGENT' - Disconnects and reconnects: LDAP agent. \t- 'AD_AGENT' - Disconnects and reconnects: AD agent. \t- 'OKTA_ANNOUNCEMENT' - Okta release notes and announcements. \t- 'OKTA_UPDATE' - Scheduled system updates. \t- 'IWA_AGENT' - Disconnects and reconnects: IWA agent. \t- 'USER_DEPROVISION' - User deprovisions. \t- 'REPORT_SUSPICIOUS_ACTIVITY' - User reporting of suspicious activity. \t- 'RATELIMIT_NOTIFICATION' - Rate limit warning and violation. \t- 'AGENT_AUTO_UPDATE_NOTIFICATION' - Agent auto-update notifications: AD Agent.",
   withNotificationType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"notification_type" expected to be of type "string"';
+    assert std.isString(value) : '"notification_type" expected to be of type "string"';
+
     {
-      notification_type: converted,
+      notification_type: value,
     }
   ),
+
   "#withRoleType":: "Type of the role. Valid values: \t'API_ADMIN', \t'APP_ADMIN', \t'CUSTOM', \t'GROUP_MEMBERSHIP_ADMIN', \t'HELP_DESK_ADMIN', \t'MOBILE_ADMIN', \t'ORG_ADMIN', \t'READ_ONLY_ADMIN', \t'REPORT_ADMIN', \t'SUPER_ADMIN', \t'USER_ADMIN' \t. See [API docs](https://developer.okta.com/docs/reference/api/admin-notifications/#role-types).",
   withRoleType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"role_type" expected to be of type "string"';
+    assert std.isString(value) : '"role_type" expected to be of type "string"';
+
     {
-      role_type: converted,
+      role_type: value,
     }
   ),
+
   "#withStatus":: "Subscription status. Valid values: `subscribed`, `unsubscribed`.",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_security_notification_emails.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_security_notification_emails.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName):: (
     {
       jsonnetTfMetadata:: {
@@ -12,51 +13,57 @@
       },
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withReportSuspiciousActivityEnabled":: "Notifies end users about suspicious or unrecognized activity from their account. Default is `true`.",
   withReportSuspiciousActivityEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"report_suspicious_activity_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"report_suspicious_activity_enabled" expected to be of type "bool"';
+
     {
-      report_suspicious_activity_enabled: converted,
+      report_suspicious_activity_enabled: value,
     }
   ),
+
   "#withSendEmailForFactorEnrollmentEnabled":: "Notifies end users of any activity on their account related to MFA factor enrollment. Default is `true`.",
   withSendEmailForFactorEnrollmentEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"send_email_for_factor_enrollment_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"send_email_for_factor_enrollment_enabled" expected to be of type "bool"';
+
     {
-      send_email_for_factor_enrollment_enabled: converted,
+      send_email_for_factor_enrollment_enabled: value,
     }
   ),
+
   "#withSendEmailForFactorResetEnabled":: "Notifies end users that one or more factors have been reset for their account. Default is `true`.",
   withSendEmailForFactorResetEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"send_email_for_factor_reset_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"send_email_for_factor_reset_enabled" expected to be of type "bool"';
+
     {
-      send_email_for_factor_reset_enabled: converted,
+      send_email_for_factor_reset_enabled: value,
     }
   ),
+
   "#withSendEmailForNewDeviceEnabled":: "Notifies end users about new sign-on activity. Default is `true`.",
   withSendEmailForNewDeviceEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"send_email_for_new_device_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"send_email_for_new_device_enabled" expected to be of type "bool"';
+
     {
-      send_email_for_new_device_enabled: converted,
+      send_email_for_new_device_enabled: value,
     }
   ),
+
   "#withSendEmailForPasswordChangedEnabled":: "Notifies end users that the password for their account has changed. Default is `true`.",
   withSendEmailForPasswordChangedEnabled(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"send_email_for_password_changed_enabled" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"send_email_for_password_changed_enabled" expected to be of type "bool"';
+
     {
-      send_email_for_password_changed_enabled: converted,
+      send_email_for_password_changed_enabled: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_template_sms.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_template_sms.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, template, type):: (
     {
       jsonnetTfMetadata:: {
@@ -14,27 +15,30 @@
     + block.withTemplate(template)
     + block.withType(type)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withTemplate":: "SMS default template",
   withTemplate(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"template" expected to be of type "string"';
+    assert std.isString(value) : '"template" expected to be of type "string"';
+
     {
-      template: converted,
+      template: value,
     }
   ),
+
   "#withType":: "SMS template type",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
   withTerraformName(value):: {
@@ -44,34 +48,38 @@
       },
     },
   },
+
   translations:: {
     local block = self,
+
     new(language, template):: (
       {}
       + block.withLanguage(language)
       + block.withTemplate(template)
     ),
+
     "#withLanguage":: "The language to map the template to.",
     withLanguage(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"language" expected to be of type "string"';
+      assert std.isString(value) : '"language" expected to be of type "string"';
+
       {
-        language: converted,
+        language: value,
       }
     ),
+
     "#withTemplate":: "The SMS message.",
     withTemplate(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"template" expected to be of type "string"';
+      assert std.isString(value) : '"template" expected to be of type "string"';
+
       {
-        template: converted,
+        template: value,
       }
     ),
   },
   withTranslations(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      translations: value,
+      translations: converted,
     }
   ),
   withTranslationsMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_theme.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_theme.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, brandId):: (
     {
       jsonnetTfMetadata:: {
@@ -13,108 +14,121 @@
     }
     + block.withBrandId(brandId)
   ),
+
   "#withBackgroundImage":: "Path to local file",
   withBackgroundImage(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"background_image" expected to be of type "string"';
+    assert std.isString(value) : '"background_image" expected to be of type "string"';
+
     {
-      background_image: converted,
+      background_image: value,
     }
   ),
+
   "#withBrandId":: "Brand ID",
   withBrandId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"brand_id" expected to be of type "string"';
+    assert std.isString(value) : '"brand_id" expected to be of type "string"';
+
     {
-      brand_id: converted,
+      brand_id: value,
     }
   ),
+
   "#withEmailTemplateTouchPointVariant":: "Variant for email templates (`OKTA_DEFAULT`, `FULL_THEME`)",
   withEmailTemplateTouchPointVariant(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"email_template_touch_point_variant" expected to be of type "string"';
+    assert std.isString(value) : '"email_template_touch_point_variant" expected to be of type "string"';
+
     {
-      email_template_touch_point_variant: converted,
+      email_template_touch_point_variant: value,
     }
   ),
+
   "#withEndUserDashboardTouchPointVariant":: "Variant for the Okta End-User Dashboard (`OKTA_DEFAULT`, `WHITE_LOGO_BACKGROUND`, `FULL_THEME`, `LOGO_ON_FULL_WHITE_BACKGROUND`)",
   withEndUserDashboardTouchPointVariant(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"end_user_dashboard_touch_point_variant" expected to be of type "string"';
+    assert std.isString(value) : '"end_user_dashboard_touch_point_variant" expected to be of type "string"';
+
     {
-      end_user_dashboard_touch_point_variant: converted,
+      end_user_dashboard_touch_point_variant: value,
     }
   ),
+
   "#withErrorPageTouchPointVariant":: "Variant for the error page (`OKTA_DEFAULT`, `BACKGROUND_SECONDARY_COLOR`, `BACKGROUND_IMAGE`)",
   withErrorPageTouchPointVariant(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"error_page_touch_point_variant" expected to be of type "string"';
+    assert std.isString(value) : '"error_page_touch_point_variant" expected to be of type "string"';
+
     {
-      error_page_touch_point_variant: converted,
+      error_page_touch_point_variant: value,
     }
   ),
+
   "#withFavicon":: "Path to local file",
   withFavicon(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"favicon" expected to be of type "string"';
+    assert std.isString(value) : '"favicon" expected to be of type "string"';
+
     {
-      favicon: converted,
+      favicon: value,
     }
   ),
+
   "#withLogo":: "Path to local file",
   withLogo(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"logo" expected to be of type "string"';
+    assert std.isString(value) : '"logo" expected to be of type "string"';
+
     {
-      logo: converted,
+      logo: value,
     }
   ),
+
   "#withPrimaryColorContrastHex":: "Primary color contrast hex code",
   withPrimaryColorContrastHex(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"primary_color_contrast_hex" expected to be of type "string"';
+    assert std.isString(value) : '"primary_color_contrast_hex" expected to be of type "string"';
+
     {
-      primary_color_contrast_hex: converted,
+      primary_color_contrast_hex: value,
     }
   ),
+
   "#withPrimaryColorHex":: "Primary color hex code",
   withPrimaryColorHex(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"primary_color_hex" expected to be of type "string"';
+    assert std.isString(value) : '"primary_color_hex" expected to be of type "string"';
+
     {
-      primary_color_hex: converted,
+      primary_color_hex: value,
     }
   ),
+
   "#withSecondaryColorContrastHex":: "Secondary color contrast hex code",
   withSecondaryColorContrastHex(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"secondary_color_contrast_hex" expected to be of type "string"';
+    assert std.isString(value) : '"secondary_color_contrast_hex" expected to be of type "string"';
+
     {
-      secondary_color_contrast_hex: converted,
+      secondary_color_contrast_hex: value,
     }
   ),
+
   "#withSecondaryColorHex":: "Secondary color hex code",
   withSecondaryColorHex(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"secondary_color_hex" expected to be of type "string"';
+    assert std.isString(value) : '"secondary_color_hex" expected to be of type "string"';
+
     {
-      secondary_color_hex: converted,
+      secondary_color_hex: value,
     }
   ),
+
   "#withSignInPageTouchPointVariant":: "Variant for the Okta Sign-In Page (`OKTA_DEFAULT`, `BACKGROUND_SECONDARY_COLOR`, `BACKGROUND_IMAGE`)",
   withSignInPageTouchPointVariant(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"sign_in_page_touch_point_variant" expected to be of type "string"';
+    assert std.isString(value) : '"sign_in_page_touch_point_variant" expected to be of type "string"';
+
     {
-      sign_in_page_touch_point_variant: converted,
+      sign_in_page_touch_point_variant: value,
     }
   ),
+
   "#withThemeId":: "Theme ID - Note: Okta API for theme only reads and updates therefore the okta_theme resource needs to act as a quasi data source. Do this by setting theme_id.",
   withThemeId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"theme_id" expected to be of type "string"';
+    assert std.isString(value) : '"theme_id" expected to be of type "string"';
+
     {
-      theme_id: converted,
+      theme_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_threat_insight_settings.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_threat_insight_settings.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, action):: (
     {
       jsonnetTfMetadata:: {
@@ -13,33 +14,39 @@
     }
     + block.withAction(action)
   ),
+
   "#withAction":: "Specifies how Okta responds to authentication requests from suspicious IPs. Valid values are `none`, `audit`, or `block`. A value of `none` indicates that ThreatInsight is disabled. A value of `audit` indicates that Okta logs suspicious requests in the System Log. A value of `block` indicates that Okta logs suspicious requests in the System Log and blocks the requests.",
   withAction(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"action" expected to be of type "string"';
+    assert std.isString(value) : '"action" expected to be of type "string"';
+
     {
-      action: converted,
+      action: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withNetworkExcludes":: "Accepts a list of Network Zone IDs. Can only accept zones of `IP` type. IPs in the excluded Network Zones aren't logged or blocked by Okta ThreatInsight and proceed to Sign On rules evaluation. This ensures that traffic from known, trusted IPs isn't accidentally logged or blocked. The ordering of the network zone is not guarantee from the API sides",
   withNetworkExcludes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_excludes" expected to be of type "list"';
+
     {
       network_excludes: converted,
     }
   ),
+
   "#withNetworkExcludesMixin":: "Accepts a list of Network Zone IDs. Can only accept zones of `IP` type. IPs in the excluded Network Zones aren't logged or blocked by Okta ThreatInsight and proceed to Sign On rules evaluation. This ensures that traffic from known, trusted IPs isn't accidentally logged or blocked. The ordering of the network zone is not guarantee from the API sides",
   withNetworkExcludesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"network_excludes" expected to be of type "list"';
+
     {
       network_excludes+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_trusted_origin.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_trusted_origin.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, name, origin, scopes):: (
     {
       jsonnetTfMetadata:: {
@@ -15,49 +16,57 @@
     + block.withOrigin(origin)
     + block.withScopes(scopes)
   ),
+
   "#withActive":: "Whether the Trusted Origin is active or not - can only be issued post-creation. By default, it is `true`.",
   withActive(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"active" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"active" expected to be of type "bool"';
+
     {
-      active: converted,
+      active: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Unique name for this trusted origin",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
+
   "#withOrigin":: "Unique origin URL for this trusted origin",
   withOrigin(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"origin" expected to be of type "string"';
+    assert std.isString(value) : '"origin" expected to be of type "string"';
+
     {
-      origin: converted,
+      origin: value,
     }
   ),
+
   "#withScopes":: "Scopes of the Trusted Origin - can either be `CORS` and/or `REDIRECT`",
   withScopes(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"scopes" expected to be of type "list"';
+
     {
       scopes: converted,
     }
   ),
+
   "#withScopesMixin":: "Scopes of the Trusted Origin - can either be `CORS` and/or `REDIRECT`",
   withScopesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"scopes" expected to be of type "list"';
+
     {
       scopes+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_trusted_server.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_trusted_server.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, authServerId, trusted):: (
     {
       jsonnetTfMetadata:: {
@@ -14,26 +15,31 @@
     + block.withAuthServerId(authServerId)
     + block.withTrusted(trusted)
   ),
+
   "#withAuthServerId":: "Authorization server ID",
   withAuthServerId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"auth_server_id" expected to be of type "string"';
+    assert std.isString(value) : '"auth_server_id" expected to be of type "string"';
+
     {
-      auth_server_id: converted,
+      auth_server_id: value,
     }
   ),
+
   "#withTrusted":: "A list of the authorization server IDs user want to trust",
   withTrusted(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"trusted" expected to be of type "set"';
+
     {
       trusted: converted,
     }
   ),
+
   "#withTrustedMixin":: "A list of the authorization server IDs user want to trust",
   withTrustedMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"trusted" expected to be of type "set"';
+
     {
       trusted+: converted,
     }

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_user.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_user.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, email, firstName, lastName, login):: (
     {
       jsonnetTfMetadata:: {
@@ -16,347 +17,392 @@
     + block.withLastName(lastName)
     + block.withLogin(login)
   ),
+
   "#withCity":: "User city",
   withCity(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"city" expected to be of type "string"';
+    assert std.isString(value) : '"city" expected to be of type "string"';
+
     {
-      city: converted,
+      city: value,
     }
   ),
+
   "#withCostCenter":: "User cost center",
   withCostCenter(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"cost_center" expected to be of type "string"';
+    assert std.isString(value) : '"cost_center" expected to be of type "string"';
+
     {
-      cost_center: converted,
+      cost_center: value,
     }
   ),
+
   "#withCountryCode":: "User country code",
   withCountryCode(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"country_code" expected to be of type "string"';
+    assert std.isString(value) : '"country_code" expected to be of type "string"';
+
     {
-      country_code: converted,
+      country_code: value,
     }
   ),
+
   "#withCustomProfileAttributes":: "JSON formatted custom attributes for a user. It must be JSON due to various types Okta allows.",
   withCustomProfileAttributes(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"custom_profile_attributes" expected to be of type "string"';
+    assert std.isString(value) : '"custom_profile_attributes" expected to be of type "string"';
+
     {
-      custom_profile_attributes: converted,
+      custom_profile_attributes: value,
     }
   ),
+
   "#withCustomProfileAttributesToIgnore":: "List of custom_profile_attribute keys that should be excluded from being managed by Terraform. This is useful in situations where specific custom fields may contain sensitive information and should be managed outside of Terraform.",
   withCustomProfileAttributesToIgnore(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"custom_profile_attributes_to_ignore" expected to be of type "set"';
+
     {
       custom_profile_attributes_to_ignore: converted,
     }
   ),
+
   "#withCustomProfileAttributesToIgnoreMixin":: "List of custom_profile_attribute keys that should be excluded from being managed by Terraform. This is useful in situations where specific custom fields may contain sensitive information and should be managed outside of Terraform.",
   withCustomProfileAttributesToIgnoreMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"custom_profile_attributes_to_ignore" expected to be of type "set"';
+
     {
       custom_profile_attributes_to_ignore+: converted,
     }
   ),
+
   "#withDepartment":: "User department",
   withDepartment(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"department" expected to be of type "string"';
+    assert std.isString(value) : '"department" expected to be of type "string"';
+
     {
-      department: converted,
+      department: value,
     }
   ),
+
   "#withDisplayName":: "User display name, suitable to show end users",
   withDisplayName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"display_name" expected to be of type "string"';
+    assert std.isString(value) : '"display_name" expected to be of type "string"';
+
     {
-      display_name: converted,
+      display_name: value,
     }
   ),
+
   "#withDivision":: "User division",
   withDivision(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"division" expected to be of type "string"';
+    assert std.isString(value) : '"division" expected to be of type "string"';
+
     {
-      division: converted,
+      division: value,
     }
   ),
+
   "#withEmail":: "User primary email address",
   withEmail(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"email" expected to be of type "string"';
+    assert std.isString(value) : '"email" expected to be of type "string"';
+
     {
-      email: converted,
+      email: value,
     }
   ),
+
   "#withEmployeeNumber":: "User employee number",
   withEmployeeNumber(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"employee_number" expected to be of type "string"';
+    assert std.isString(value) : '"employee_number" expected to be of type "string"';
+
     {
-      employee_number: converted,
+      employee_number: value,
     }
   ),
+
   "#withExpirePasswordOnCreate":: "If set to `true`, the user will have to change the password at the next login. This property will be used when user is being created and works only when `password` field is set. Default: `false`",
   withExpirePasswordOnCreate(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"expire_password_on_create" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"expire_password_on_create" expected to be of type "bool"';
+
     {
-      expire_password_on_create: converted,
+      expire_password_on_create: value,
     }
   ),
+
   "#withFirstName":: "User first name",
   withFirstName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"first_name" expected to be of type "string"';
+    assert std.isString(value) : '"first_name" expected to be of type "string"';
+
     {
-      first_name: converted,
+      first_name: value,
     }
   ),
+
   "#withHonorificPrefix":: "User honorific prefix",
   withHonorificPrefix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"honorific_prefix" expected to be of type "string"';
+    assert std.isString(value) : '"honorific_prefix" expected to be of type "string"';
+
     {
-      honorific_prefix: converted,
+      honorific_prefix: value,
     }
   ),
+
   "#withHonorificSuffix":: "User honorific suffix",
   withHonorificSuffix(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"honorific_suffix" expected to be of type "string"';
+    assert std.isString(value) : '"honorific_suffix" expected to be of type "string"';
+
     {
-      honorific_suffix: converted,
+      honorific_suffix: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withLastName":: "User last name",
   withLastName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"last_name" expected to be of type "string"';
+    assert std.isString(value) : '"last_name" expected to be of type "string"';
+
     {
-      last_name: converted,
+      last_name: value,
     }
   ),
+
   "#withLocale":: "User default location",
   withLocale(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"locale" expected to be of type "string"';
+    assert std.isString(value) : '"locale" expected to be of type "string"';
+
     {
-      locale: converted,
+      locale: value,
     }
   ),
+
   "#withLogin":: "User Okta login",
   withLogin(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"login" expected to be of type "string"';
+    assert std.isString(value) : '"login" expected to be of type "string"';
+
     {
-      login: converted,
+      login: value,
     }
   ),
+
   "#withManager":: "Manager of User",
   withManager(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"manager" expected to be of type "string"';
+    assert std.isString(value) : '"manager" expected to be of type "string"';
+
     {
-      manager: converted,
+      manager: value,
     }
   ),
+
   "#withManagerId":: "Manager ID of User",
   withManagerId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"manager_id" expected to be of type "string"';
+    assert std.isString(value) : '"manager_id" expected to be of type "string"';
+
     {
-      manager_id: converted,
+      manager_id: value,
     }
   ),
+
   "#withMiddleName":: "User middle name",
   withMiddleName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"middle_name" expected to be of type "string"';
+    assert std.isString(value) : '"middle_name" expected to be of type "string"';
+
     {
-      middle_name: converted,
+      middle_name: value,
     }
   ),
+
   "#withMobilePhone":: "User mobile phone number",
   withMobilePhone(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"mobile_phone" expected to be of type "string"';
+    assert std.isString(value) : '"mobile_phone" expected to be of type "string"';
+
     {
-      mobile_phone: converted,
+      mobile_phone: value,
     }
   ),
+
   "#withNickName":: "User nickname",
   withNickName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"nick_name" expected to be of type "string"';
+    assert std.isString(value) : '"nick_name" expected to be of type "string"';
+
     {
-      nick_name: converted,
+      nick_name: value,
     }
   ),
+
   "#withOldPassword":: "Old User Password. Should be only set in case the password was not changed using the provider. fter successful password change this field should be removed and `password` field should be used for further changes.",
   withOldPassword(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"old_password" expected to be of type "string"';
+    assert std.isString(value) : '"old_password" expected to be of type "string"';
+
     {
-      old_password: converted,
+      old_password: value,
     }
   ),
+
   "#withOrganization":: "User organization",
   withOrganization(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"organization" expected to be of type "string"';
+    assert std.isString(value) : '"organization" expected to be of type "string"';
+
     {
-      organization: converted,
+      organization: value,
     }
   ),
+
   "#withPassword":: "User Password",
   withPassword(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"password" expected to be of type "string"';
+    assert std.isString(value) : '"password" expected to be of type "string"';
+
     {
-      password: converted,
+      password: value,
     }
   ),
+
   "#withPasswordInlineHook":: "Specifies that a Password Import Inline Hook should be triggered to handle verification of the user's password the first time the user logs in. This allows an existing password to be imported into Okta directly from some other store. When updating a user with a password hook the user must be in the `STAGED` status. The `password` field should not be specified when using Password Import Inline Hook.",
   withPasswordInlineHook(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"password_inline_hook" expected to be of type "string"';
+    assert std.isString(value) : '"password_inline_hook" expected to be of type "string"';
+
     {
-      password_inline_hook: converted,
+      password_inline_hook: value,
     }
   ),
+
   "#withPostalAddress":: "User mailing address",
   withPostalAddress(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"postal_address" expected to be of type "string"';
+    assert std.isString(value) : '"postal_address" expected to be of type "string"';
+
     {
-      postal_address: converted,
+      postal_address: value,
     }
   ),
+
   "#withPreferredLanguage":: "User preferred language",
   withPreferredLanguage(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"preferred_language" expected to be of type "string"';
+    assert std.isString(value) : '"preferred_language" expected to be of type "string"';
+
     {
-      preferred_language: converted,
+      preferred_language: value,
     }
   ),
+
   "#withPrimaryPhone":: "User primary phone number",
   withPrimaryPhone(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"primary_phone" expected to be of type "string"';
+    assert std.isString(value) : '"primary_phone" expected to be of type "string"';
+
     {
-      primary_phone: converted,
+      primary_phone: value,
     }
   ),
+
   "#withProfileUrl":: "User online profile (web page)",
   withProfileUrl(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"profile_url" expected to be of type "string"';
+    assert std.isString(value) : '"profile_url" expected to be of type "string"';
+
     {
-      profile_url: converted,
+      profile_url: value,
     }
   ),
+
   "#withRecoveryAnswer":: "User Password Recovery Answer",
   withRecoveryAnswer(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"recovery_answer" expected to be of type "string"';
+    assert std.isString(value) : '"recovery_answer" expected to be of type "string"';
+
     {
-      recovery_answer: converted,
+      recovery_answer: value,
     }
   ),
+
   "#withRecoveryQuestion":: "User Password Recovery Question",
   withRecoveryQuestion(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"recovery_question" expected to be of type "string"';
+    assert std.isString(value) : '"recovery_question" expected to be of type "string"';
+
     {
-      recovery_question: converted,
+      recovery_question: value,
     }
   ),
+
   "#withSecondEmail":: "User secondary email address, used for account recovery",
   withSecondEmail(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"second_email" expected to be of type "string"';
+    assert std.isString(value) : '"second_email" expected to be of type "string"';
+
     {
-      second_email: converted,
+      second_email: value,
     }
   ),
+
   "#withSkipRoles":: "Do not populate user roles information (prevents additional API call)",
   withSkipRoles(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"skip_roles" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"skip_roles" expected to be of type "bool"';
+
     {
-      skip_roles: converted,
+      skip_roles: value,
     }
   ),
+
   "#withState":: "User state or region",
   withState(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"state" expected to be of type "string"';
+    assert std.isString(value) : '"state" expected to be of type "string"';
+
     {
-      state: converted,
+      state: value,
     }
   ),
+
   "#withStatus":: "User profile property. Valid values are `ACTIVE`, `DEPROVISIONED`, `STAGED`, `SUSPENDED`. Default: `ACTIVE`",
   withStatus(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"status" expected to be of type "string"';
+    assert std.isString(value) : '"status" expected to be of type "string"';
+
     {
-      status: converted,
+      status: value,
     }
   ),
+
   "#withStreetAddress":: "User street address",
   withStreetAddress(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"street_address" expected to be of type "string"';
+    assert std.isString(value) : '"street_address" expected to be of type "string"';
+
     {
-      street_address: converted,
+      street_address: value,
     }
   ),
+
   "#withTimezone":: "User default timezone",
   withTimezone(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"timezone" expected to be of type "string"';
+    assert std.isString(value) : '"timezone" expected to be of type "string"';
+
     {
-      timezone: converted,
+      timezone: value,
     }
   ),
+
   "#withTitle":: "User title",
   withTitle(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"title" expected to be of type "string"';
+    assert std.isString(value) : '"title" expected to be of type "string"';
+
     {
-      title: converted,
+      title: value,
     }
   ),
+
   "#withUserType":: "User employee type",
   withUserType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_type" expected to be of type "string"';
+
     {
-      user_type: converted,
+      user_type: value,
     }
   ),
+
   "#withZipCode":: "User zipcode or postal code",
   withZipCode(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"zip_code" expected to be of type "string"';
+    assert std.isString(value) : '"zip_code" expected to be of type "string"';
+
     {
-      zip_code: converted,
+      zip_code: value,
     }
   ),
   withTerraformName(value):: {
@@ -366,58 +412,65 @@
       },
     },
   },
+
   passwordHash:: {
     local block = self,
+
     new(algorithm, value):: (
       {}
       + block.withAlgorithm(algorithm)
       + block.withValue(value)
     ),
+
     "#withAlgorithm":: "The algorithm used to generate the hash using the password",
     withAlgorithm(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"algorithm" expected to be of type "string"';
+      assert std.isString(value) : '"algorithm" expected to be of type "string"';
+
       {
-        algorithm: converted,
+        algorithm: value,
       }
     ),
+
     "#withSalt":: "Only required for salted hashes",
     withSalt(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"salt" expected to be of type "string"';
+      assert std.isString(value) : '"salt" expected to be of type "string"';
+
       {
-        salt: converted,
+        salt: value,
       }
     ),
+
     "#withSaltOrder":: "Specifies whether salt was pre- or postfixed to the password before hashing",
     withSaltOrder(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"salt_order" expected to be of type "string"';
+      assert std.isString(value) : '"salt_order" expected to be of type "string"';
+
       {
-        salt_order: converted,
+        salt_order: value,
       }
     ),
+
     "#withValue":: "For SHA-512, SHA-256, SHA-1, MD5, This is the actual base64-encoded hash of the password (and salt, if used). This is the Base64 encoded value of the SHA-512/SHA-256/SHA-1/MD5 digest that was computed by either pre-fixing or post-fixing the salt to the password, depending on the saltOrder. If a salt was not used in the source system, then this should just be the the Base64 encoded value of the password's SHA-512/SHA-256/SHA-1/MD5 digest. For BCRYPT, This is the actual radix64-encoded hashed password.",
     withValue(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"value" expected to be of type "string"';
+      assert std.isString(value) : '"value" expected to be of type "string"';
+
       {
-        value: converted,
+        value: value,
       }
     ),
+
     "#withWorkFactor":: "Governs the strength of the hash and the time required to compute it. Only required for BCRYPT algorithm",
     withWorkFactor(value):: (
-      local converted = value;
-      assert std.isNumber(converted) : '"work_factor" expected to be of type "number"';
+      assert std.isNumber(value) : '"work_factor" expected to be of type "number"';
+
       {
-        work_factor: converted,
+        work_factor: value,
       }
     ),
   },
   withPasswordHash(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      password_hash: value,
+      password_hash: converted,
     }
   ),
   withPasswordHashMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_user_admin_roles.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_user_admin_roles.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, adminRoles, userId):: (
     {
       jsonnetTfMetadata:: {
@@ -14,43 +15,50 @@
     + block.withAdminRoles(adminRoles)
     + block.withUserId(userId)
   ),
+
   "#withAdminRoles":: "The list of Okta user admin roles, e.g. `['APP_ADMIN', 'USER_ADMIN']` See [API Docs](https://developer.okta.com/docs/api/openapi/okta-management/guides/roles/#standard-roles).",
   withAdminRoles(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"admin_roles" expected to be of type "set"';
+
     {
       admin_roles: converted,
     }
   ),
+
   "#withAdminRolesMixin":: "The list of Okta user admin roles, e.g. `['APP_ADMIN', 'USER_ADMIN']` See [API Docs](https://developer.okta.com/docs/api/openapi/okta-management/guides/roles/#standard-roles).",
   withAdminRolesMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"admin_roles" expected to be of type "set"';
+
     {
       admin_roles+: converted,
     }
   ),
+
   "#withDisableNotifications":: "When this setting is enabled, the admins won't receive any of the default Okta administrator emails. These admins also won't have access to contact Okta Support and open support cases on behalf of your org.",
   withDisableNotifications(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"disable_notifications" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"disable_notifications" expected to be of type "bool"';
+
     {
-      disable_notifications: converted,
+      disable_notifications: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withUserId":: "ID of a Okta User",
   withUserId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_id" expected to be of type "string"';
+    assert std.isString(value) : '"user_id" expected to be of type "string"';
+
     {
-      user_id: converted,
+      user_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_user_base_schema_property.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_user_base_schema_property.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, index, title, type):: (
     {
       jsonnetTfMetadata:: {
@@ -15,75 +16,84 @@
     + block.withTitle(title)
     + block.withType(type)
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIndex":: "Subschema unique string identifier",
   withIndex(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"index" expected to be of type "string"';
+    assert std.isString(value) : '"index" expected to be of type "string"';
+
     {
-      index: converted,
+      index: value,
     }
   ),
+
   "#withMaster":: "Master priority for the user schema property. It can be set to `PROFILE_MASTER` or `OKTA`. Default: `PROFILE_MASTER`",
   withMaster(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"master" expected to be of type "string"';
+    assert std.isString(value) : '"master" expected to be of type "string"';
+
     {
-      master: converted,
+      master: value,
     }
   ),
+
   "#withPattern":: "The validation pattern to use for the subschema. Must be in form of '.+', or '[<pattern>]+' if present.'",
   withPattern(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"pattern" expected to be of type "string"';
+    assert std.isString(value) : '"pattern" expected to be of type "string"';
+
     {
-      pattern: converted,
+      pattern: value,
     }
   ),
+
   "#withPermissions":: "Access control permissions for the property. It can be set to `READ_WRITE`, `READ_ONLY`, `HIDE`. Default: `READ_ONLY`",
   withPermissions(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"permissions" expected to be of type "string"';
+    assert std.isString(value) : '"permissions" expected to be of type "string"';
+
     {
-      permissions: converted,
+      permissions: value,
     }
   ),
+
   "#withRequired":: "Whether the subschema is required",
   withRequired(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"required" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"required" expected to be of type "bool"';
+
     {
-      required: converted,
+      required: value,
     }
   ),
+
   "#withTitle":: "Subschema title (display name)",
   withTitle(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"title" expected to be of type "string"';
+    assert std.isString(value) : '"title" expected to be of type "string"';
+
     {
-      title: converted,
+      title: value,
     }
   ),
+
   "#withType":: "The type of the schema property. It can be `string`, `boolean`, `number`, `integer`, `array`, or `object`",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
+
   "#withUserType":: "User type ID. By default, it is `default`",
   withUserType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_type" expected to be of type "string"';
+
     {
-      user_type: converted,
+      user_type: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_user_factor_question.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_user_factor_question.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, answer, key, userId):: (
     {
       jsonnetTfMetadata:: {
@@ -15,35 +16,39 @@
     + block.withKey(key)
     + block.withUserId(userId)
   ),
+
   "#withAnswer":: "Security question answer. Note here that answer won't be set during the resource import.",
   withAnswer(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"answer" expected to be of type "string"';
+    assert std.isString(value) : '"answer" expected to be of type "string"';
+
     {
-      answer: converted,
+      answer: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withKey":: "Security question unique key. ",
   withKey(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"key" expected to be of type "string"';
+    assert std.isString(value) : '"key" expected to be of type "string"';
+
     {
-      key: converted,
+      key: value,
     }
   ),
+
   "#withUserId":: "ID of the user. Resource will be recreated when `user_id` changes.",
   withUserId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_id" expected to be of type "string"';
+    assert std.isString(value) : '"user_id" expected to be of type "string"';
+
     {
-      user_id: converted,
+      user_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_user_group_memberships.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_user_group_memberships.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, groups, userId):: (
     {
       jsonnetTfMetadata:: {
@@ -14,35 +15,41 @@
     + block.withGroups(groups)
     + block.withUserId(userId)
   ),
+
   "#withGroups":: "The list of Okta group IDs which the user should have membership managed for.",
   withGroups(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups" expected to be of type "set"';
+
     {
       groups: converted,
     }
   ),
+
   "#withGroupsMixin":: "The list of Okta group IDs which the user should have membership managed for.",
   withGroupsMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert (std.isArray(converted) && std.length(std.set(converted)) == std.length(converted)) : '"groups" expected to be of type "set"';
+
     {
       groups+: converted,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withUserId":: "ID of a Okta User",
   withUserId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_id" expected to be of type "string"';
+    assert std.isString(value) : '"user_id" expected to be of type "string"';
+
     {
-      user_id: converted,
+      user_id: value,
     }
   ),
   withTerraformName(value):: {

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_user_schema_property.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_user_schema_property.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, index, title, type):: (
     {
       jsonnetTfMetadata:: {
@@ -15,171 +16,196 @@
     + block.withTitle(title)
     + block.withType(type)
   ),
+
   "#withArrayEnum":: "Array of values that an array property's items can be set to.",
   withArrayEnum(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"array_enum" expected to be of type "list"';
+
     {
       array_enum: converted,
     }
   ),
+
   "#withArrayEnumMixin":: "Array of values that an array property's items can be set to.",
   withArrayEnumMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"array_enum" expected to be of type "list"';
+
     {
       array_enum+: converted,
     }
   ),
+
   "#withArrayType":: "The type of the array elements if `type` is set to `array`",
   withArrayType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"array_type" expected to be of type "string"';
+    assert std.isString(value) : '"array_type" expected to be of type "string"';
+
     {
-      array_type: converted,
+      array_type: value,
     }
   ),
+
   "#withDescription":: "The description of the user schema property.",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   "#withEnum":: "Array of values a primitive property can be set to. See `array_enum` for arrays.",
   withEnum(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"enum" expected to be of type "list"';
+
     {
       enum: converted,
     }
   ),
+
   "#withEnumMixin":: "Array of values a primitive property can be set to. See `array_enum` for arrays.",
   withEnumMixin(value):: (
     local converted = if std.isArray(value) then value else [value];
     assert std.isArray(converted) : '"enum" expected to be of type "list"';
+
     {
       enum+: converted,
     }
   ),
+
   "#withExternalName":: "External name of the user schema property.",
   withExternalName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"external_name" expected to be of type "string"';
+    assert std.isString(value) : '"external_name" expected to be of type "string"';
+
     {
-      external_name: converted,
+      external_name: value,
     }
   ),
+
   "#withExternalNamespace":: "External namespace of the user schema property.",
   withExternalNamespace(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"external_namespace" expected to be of type "string"';
+    assert std.isString(value) : '"external_namespace" expected to be of type "string"';
+
     {
-      external_namespace: converted,
+      external_namespace: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withIndex":: "Subschema unique string identifier",
   withIndex(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"index" expected to be of type "string"';
+    assert std.isString(value) : '"index" expected to be of type "string"';
+
     {
-      index: converted,
+      index: value,
     }
   ),
+
   "#withMaster":: " Master priority for the user schema property. It can be set to `PROFILE_MASTER`, `OVERRIDE` or `OKTA`.",
   withMaster(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"master" expected to be of type "string"';
+    assert std.isString(value) : '"master" expected to be of type "string"';
+
     {
-      master: converted,
+      master: value,
     }
   ),
+
   "#withMaxLength":: "The maximum length of the user property value. Only applies to type `string`",
   withMaxLength(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"max_length" expected to be of type "number"';
+    assert std.isNumber(value) : '"max_length" expected to be of type "number"';
+
     {
-      max_length: converted,
+      max_length: value,
     }
   ),
+
   "#withMinLength":: "The minimum length of the user property value. Only applies to type `string`",
   withMinLength(value):: (
-    local converted = value;
-    assert std.isNumber(converted) : '"min_length" expected to be of type "number"';
+    assert std.isNumber(value) : '"min_length" expected to be of type "number"';
+
     {
-      min_length: converted,
+      min_length: value,
     }
   ),
+
   "#withPattern":: "The validation pattern to use for the subschema. Must be in form of '.+', or '[<pattern>]+' if present.'",
   withPattern(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"pattern" expected to be of type "string"';
+    assert std.isString(value) : '"pattern" expected to be of type "string"';
+
     {
-      pattern: converted,
+      pattern: value,
     }
   ),
+
   "#withPermissions":: "Access control permissions for the property. It can be set to `READ_WRITE`, `READ_ONLY`, `HIDE`. Default: `READ_ONLY`",
   withPermissions(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"permissions" expected to be of type "string"';
+    assert std.isString(value) : '"permissions" expected to be of type "string"';
+
     {
-      permissions: converted,
+      permissions: value,
     }
   ),
+
   "#withRequired":: "Whether the subschema is required",
   withRequired(value):: (
-    local converted = value;
-    assert std.isBoolean(converted) : '"required" expected to be of type "bool"';
+    assert std.isBoolean(value) : '"required" expected to be of type "bool"';
+
     {
-      required: converted,
+      required: value,
     }
   ),
+
   "#withScope":: "determines whether an app user attribute can be set at the Individual or Group Level. Default: `NONE`",
   withScope(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"scope" expected to be of type "string"';
+    assert std.isString(value) : '"scope" expected to be of type "string"';
+
     {
-      scope: converted,
+      scope: value,
     }
   ),
+
   "#withTitle":: "Subschema title (display name)",
   withTitle(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"title" expected to be of type "string"';
+    assert std.isString(value) : '"title" expected to be of type "string"';
+
     {
-      title: converted,
+      title: value,
     }
   ),
+
   "#withType":: "The type of the schema property. It can be `string`, `boolean`, `number`, `integer`, `array`, or `object`",
   withType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"type" expected to be of type "string"';
+    assert std.isString(value) : '"type" expected to be of type "string"';
+
     {
-      type: converted,
+      type: value,
     }
   ),
+
   "#withUnique":: "Whether the property should be unique. It can be set to `UNIQUE_VALIDATED` or `NOT_UNIQUE`.",
   withUnique(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"unique" expected to be of type "string"';
+    assert std.isString(value) : '"unique" expected to be of type "string"';
+
     {
-      unique: converted,
+      unique: value,
     }
   ),
+
   "#withUserType":: "User type ID. By default, it is `default`",
   withUserType(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"user_type" expected to be of type "string"';
+    assert std.isString(value) : '"user_type" expected to be of type "string"';
+
     {
-      user_type: converted,
+      user_type: value,
     }
   ),
   withTerraformName(value):: {
@@ -189,91 +215,101 @@
       },
     },
   },
+
   arrayOneOf:: {
     local block = self,
+
     new(const, title):: (
       {}
       + block.withConst(const)
       + block.withTitle(title)
     ),
+
     "#withConst":: "Value mapping to member of `array_enum`",
     withConst(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"const" expected to be of type "string"';
+      assert std.isString(value) : '"const" expected to be of type "string"';
+
       {
-        const: converted,
+        const: value,
       }
     ),
+
     "#withTitle":: "Display name for the enum value.",
     withTitle(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"title" expected to be of type "string"';
+      assert std.isString(value) : '"title" expected to be of type "string"';
+
       {
-        title: converted,
+        title: value,
       }
     ),
   },
   masterOverridePriority:: {
     local block = self,
+
     new(value):: (
       {}
       + block.withValue(value)
     ),
+
     withType(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"type" expected to be of type "string"';
+      assert std.isString(value) : '"type" expected to be of type "string"';
+
       {
-        type: converted,
+        type: value,
       }
     ),
+
     withValue(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"value" expected to be of type "string"';
+      assert std.isString(value) : '"value" expected to be of type "string"';
+
       {
-        value: converted,
+        value: value,
       }
     ),
   },
   oneOf:: {
     local block = self,
+
     new(const, title):: (
       {}
       + block.withConst(const)
       + block.withTitle(title)
     ),
+
     "#withConst":: "Enum value",
     withConst(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"const" expected to be of type "string"';
+      assert std.isString(value) : '"const" expected to be of type "string"';
+
       {
-        const: converted,
+        const: value,
       }
     ),
+
     "#withTitle":: "Enum title",
     withTitle(value):: (
-      local converted = value;
-      assert std.isString(converted) : '"title" expected to be of type "string"';
+      assert std.isString(value) : '"title" expected to be of type "string"';
+
       {
-        title: converted,
+        title: value,
       }
     ),
   },
   withArrayOneOf(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      array_one_of: value,
+      array_one_of: converted,
     }
   ),
   withMasterOverridePriority(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      master_override_priority: value,
+      master_override_priority: converted,
     }
   ),
   withOneOf(value):: (
     local converted = if std.isArray(value) then value else [value];
     {
-      one_of: value,
+      one_of: converted,
     }
   ),
   withArrayOneOfMixin(value):: (

--- a/tests/expected/registry.terraform.io/okta/okta/resource/okta_user_type.libsonnet
+++ b/tests/expected/registry.terraform.io/okta/okta/resource/okta_user_type.libsonnet
@@ -1,5 +1,6 @@
 {
   local block = self,
+
   new(terraformName, description, displayName, name):: (
     {
       jsonnetTfMetadata:: {
@@ -15,35 +16,39 @@
     + block.withDisplayName(displayName)
     + block.withName(name)
   ),
+
   "#withDescription":: "Description of the User Type.",
   withDescription(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"description" expected to be of type "string"';
+    assert std.isString(value) : '"description" expected to be of type "string"';
+
     {
-      description: converted,
+      description: value,
     }
   ),
+
   "#withDisplayName":: "Display Name of the User Type.",
   withDisplayName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"display_name" expected to be of type "string"';
+    assert std.isString(value) : '"display_name" expected to be of type "string"';
+
     {
-      display_name: converted,
+      display_name: value,
     }
   ),
+
   withId(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"id" expected to be of type "string"';
+    assert std.isString(value) : '"id" expected to be of type "string"';
+
     {
-      id: converted,
+      id: value,
     }
   ),
+
   "#withName":: "Name of the User Type.",
   withName(value):: (
-    local converted = value;
-    assert std.isString(converted) : '"name" expected to be of type "string"';
+    assert std.isString(value) : '"name" expected to be of type "string"';
+
     {
-      name: converted,
+      name: value,
     }
   ),
   withTerraformName(value):: {


### PR DESCRIPTION
- added an extra new line before some functions
- removed redundant conversion for vars that are not converted